### PR TITLE
map tool overlay and LLOS stability workaround

### DIFF
--- a/source/Visibility/ProAppVisibilityModule/Models/ProGraphic.cs
+++ b/source/Visibility/ProAppVisibilityModule/Models/ProGraphic.cs
@@ -19,12 +19,13 @@ namespace ProAppVisibilityModule.Models
 {
     public class ProGraphic
     {
-        public ProGraphic(IDisposable _disposable, string guid, Geometry _geometry, bool _isTemp = false)
+        public ProGraphic(IDisposable _disposable, string guid, Geometry _geometry, bool _isTemp = false, string tag = "")
         {
             Disposable = _disposable;
             GUID = guid;
             Geometry = _geometry;
             IsTemp = _isTemp;
+            Tag = tag;
         }
 
         // properties   
@@ -50,6 +51,11 @@ namespace ProAppVisibilityModule.Models
         /// Property to determine if graphic is temporary or not
         /// </summary>
         public bool IsTemp { get; set; }
+
+        /// <summary>
+        /// optional tag property
+        /// </summary>
+        public string Tag { get; set; }
 
     }
 }

--- a/source/Visibility/ProAppVisibilityModule/ViewModels/ProLLOSViewModel.cs
+++ b/source/Visibility/ProAppVisibilityModule/ViewModels/ProLLOSViewModel.cs
@@ -170,7 +170,7 @@ namespace ProAppVisibilityModule.ViewModels
 
             if (ToolMode == MapPointToolMode.Target)
             {
-                var guid = await AddGraphicToMap(point, ColorFactory.Red, true, 5.0, markerStyle: SimpleMarkerStyle.Square);
+                var guid = await AddGraphicToMap(point, ColorFactory.Red, true, 5.0, markerStyle: SimpleMarkerStyle.Square, tag: "target");
                 var addInPoint = new AddInPoint() { Point = point, GUID = guid };
                 Application.Current.Dispatcher.Invoke(() =>
                     {

--- a/source/Visibility/ProAppVisibilityModule/ViewModels/ProLLOSViewModel.cs
+++ b/source/Visibility/ProAppVisibilityModule/ViewModels/ProLLOSViewModel.cs
@@ -236,6 +236,10 @@ namespace ProAppVisibilityModule.ViewModels
 
                 DeactivateTool("ProAppVisibilityModule_MapTool");
 
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+
                 //await base.CreateMapElement();
             }
             catch(Exception ex)
@@ -288,6 +292,9 @@ namespace ProAppVisibilityModule.ViewModels
                 await FeatureClassHelper.UpdateShapeWithZ(VisibilityLibrary.Properties.Resources.TargetsLayerName, VisibilityLibrary.Properties.Resources.ZFieldName,  GetAsMapZUnits(surfaceSR, TargetOffset.Value));
 
                 // create sight lines
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
 
                 await FeatureClassHelper.CreateSightLines(VisibilityLibrary.Properties.Resources.ObserversLayerName, 
                     VisibilityLibrary.Properties.Resources.TargetsLayerName,
@@ -296,11 +303,17 @@ namespace ProAppVisibilityModule.ViewModels
                     VisibilityLibrary.Properties.Resources.OffsetWithZFieldName);
 
                 // LOS
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
 
                 await FeatureClassHelper.CreateLOS(SelectedSurfaceName, 
                     VisibilityLibrary.Properties.Resources.SightLinesLayerName,
                     CoreModule.CurrentProject.DefaultGeodatabasePath + "\\" + VisibilityLibrary.Properties.Resources.LOSOutputLayerName);
 
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
 
                 // gather results for updating observer and target layers
                 var sourceOIDs = await FeatureClassHelper.GetSourceOIDs();

--- a/source/Visibility/ProAppVisibilityModule/ViewModels/ProLLOSViewModel.cs
+++ b/source/Visibility/ProAppVisibilityModule/ViewModels/ProLLOSViewModel.cs
@@ -232,9 +232,9 @@ namespace ProAppVisibilityModule.ViewModels
                 if (!CanCreateElement || MapView.Active == null || MapView.Active.Map == null || string.IsNullOrWhiteSpace(SelectedSurfaceName))
                     return;
 
-                DeactivateTool("ProAppVisibilityModule_MapTool");
-
                 await ExecuteVisibilityLLOS();
+
+                DeactivateTool("ProAppVisibilityModule_MapTool");
 
                 //await base.CreateMapElement();
             }

--- a/source/Visibility/ProAppVisibilityModule/ViewModels/ProRLOSViewModel.cs
+++ b/source/Visibility/ProAppVisibilityModule/ViewModels/ProRLOSViewModel.cs
@@ -225,9 +225,9 @@ namespace ProAppVisibilityModule.ViewModels
                 if (!CanCreateElement || MapView.Active == null || MapView.Active.Map == null || string.IsNullOrWhiteSpace(SelectedSurfaceName))
                     return;
 
-                DeactivateTool("ProAppVisibilityModule_MapTool");
-
                 await ExecuteVisibilityRLOS();
+
+                DeactivateTool("ProAppVisibilityModule_MapTool");
 
                 //await base.CreateMapElement();
             }

--- a/source/Visibility/ProAppVisibilityModule/ViewModels/ProTabBaseViewModel.cs
+++ b/source/Visibility/ProAppVisibilityModule/ViewModels/ProTabBaseViewModel.cs
@@ -59,14 +59,30 @@ namespace ProAppVisibilityModule.ViewModels
             {
                 if (item.Disposable != null && item.IsTemp == true)
                 {
-                    item.Disposable.Dispose();
+                    if (item.Disposable != null)
+                        item.Disposable.Dispose();
                     item.Disposable = null;
                 }
             }
         }
 
+        private class tempProGraphic
+        {
+            public tempProGraphic() { }
+
+            public string GUID { get; set; }
+            public Geometry Geometry { get; set; }
+            public CIMColor Color { get; set; }
+            public bool IsTemp { get; set; }
+            public double Size { get; set; }
+            public SimpleMarkerStyle MarkerStyle { get; set; }
+        }
+
         private async void OnMapPointToolActivated(object obj)
         {
+            var addList = new List<tempProGraphic>();
+            var removeList = new List<ProGraphic>();
+
             foreach(var item in ProGraphicsList)
             {
                 if (item.Disposable != null || item.IsTemp == false)
@@ -81,10 +97,30 @@ namespace ProAppVisibilityModule.ViewModels
                     ms = SimpleMarkerStyle.Square;
                     color = ColorFactory.RedRGB;
                 }
-
-                var guid = await AddGraphicToMap(item.Geometry, color, true, 5.0, markerStyle: ms);
-                item.GUID = guid;
+                addList.Add(new tempProGraphic()
+                {
+                    GUID = item.GUID,
+                    Geometry = item.Geometry,
+                    Color = color,
+                    IsTemp = true,
+                    Size = 5.0,
+                    MarkerStyle = ms
+                });
             }
+
+            foreach(var temp in addList)
+            {
+                var pgOLD = ProGraphicsList.FirstOrDefault(g => g.GUID == temp.GUID);
+
+                var guid = await AddGraphicToMap(temp.Geometry, temp.Color, temp.IsTemp, temp.Size, markerStyle: temp.MarkerStyle, tag: pgOLD.Tag);
+
+                var pgNew = ProGraphicsList.FirstOrDefault(g => g.GUID == guid);
+                pgNew.GUID = pgOLD.GUID;
+                removeList.Add(pgOLD);
+            }
+
+            foreach (var pg in removeList)
+                ProGraphicsList.Remove(pg);
         }
 
         #region Properties
@@ -293,7 +329,8 @@ namespace ProAppVisibilityModule.ViewModels
 
                 foreach (var item in ProGraphicsList)
                 {
-                    item.Disposable.Dispose();
+                    if (item.Disposable != null)
+                        item.Disposable.Dispose();
                 }
 
                 ProGraphicsList.Clear();
@@ -372,7 +409,8 @@ namespace ProAppVisibilityModule.ViewModels
             var list = ProGraphicsList.Where(g => guidList.Contains(g.GUID)).ToList();
             foreach (var graphic in list)
             {
-                graphic.Disposable.Dispose();
+                if(graphic.Disposable != null)
+                    graphic.Disposable.Dispose();
                 ProGraphicsList.Remove(graphic);
             }
 
@@ -400,7 +438,8 @@ namespace ProAppVisibilityModule.ViewModels
 
             foreach (var item in list)
             {
-                item.Disposable.Dispose();
+                if (item.Disposable != null)
+                    item.Disposable.Dispose();
                 Application.Current.Dispatcher.Invoke(() =>
                     {
                         ProGraphicsList.Remove(item);

--- a/source/Visibility/ProAppVisibilityModule/VisibilityMapTool.cs
+++ b/source/Visibility/ProAppVisibilityModule/VisibilityMapTool.cs
@@ -32,7 +32,16 @@ namespace ProAppVisibilityModule
 
         protected override Task OnToolActivateAsync(bool active)
         {
+            Mediator.NotifyColleagues(VisibilityLibrary.Constants.MAP_POINT_TOOL_ACTIVATED, active);
+
             return base.OnToolActivateAsync(active);
+        }
+
+        protected override Task OnToolDeactivateAsync(bool hasMapViewChanged)
+        {
+            Mediator.NotifyColleagues(VisibilityLibrary.Constants.MAP_POINT_TOOL_DEACTIVATED, hasMapViewChanged);
+
+            return base.OnToolDeactivateAsync(hasMapViewChanged);
         }
 
         protected override Task<bool> OnSketchCompleteAsync(ArcGIS.Core.Geometry.Geometry geometry)

--- a/source/Visibility/VisibilityLibrary/Helpers/Constants.cs
+++ b/source/Visibility/VisibilityLibrary/Helpers/Constants.cs
@@ -29,5 +29,7 @@ namespace VisibilityLibrary
         public const string TAB_ITEM_SELECTED = "TAB_ITEM_SELECTED";
         public const string MAP_TOC_UPDATED = "MAP_TOC_UPDATED";
         public const string DISPLAY_COORDINATE_TYPE_CHANGED = "DisplayCoordinateTypeChanged";
+        public const string MAP_POINT_TOOL_ACTIVATED = "MAP_POINT_TOOL_ACTIVATED";
+        public const string MAP_POINT_TOOL_DEACTIVATED = "MAP_POINT_TOOL_DEACTIVATED";
     }
 }


### PR DESCRIPTION
Enhanced observer and target graphics to only be visible when map point tool is active
Also, forcing garbage collection between some GP calls seems to keep LLOS from having issues with file locks.