### PR TITLE
Fixed issue where LLOS projection was being tested for comparison of …

### DIFF
--- a/source/Visibility/ArcMapAddinVisibility/ViewModels/LLOSViewModel.cs
+++ b/source/Visibility/ArcMapAddinVisibility/ViewModels/LLOSViewModel.cs
@@ -184,10 +184,12 @@ namespace ArcMapAddinVisibility.ViewModels
                 if (surface == null)
                     return;
 
-                // Set Spatial Reference of selected surface
+                // Determine if selected surface is projected or geographic
                 ILayer surfaceLayer = GetLayerFromMapByName(ArcMap.Document.FocusMap, SelectedSurfaceName);
                 var geoDataset = surfaceLayer as IGeoDataset;
-                if (geoDataset != null && ArcMap.Document.FocusMap.SpatialReference.FactoryCode != geoDataset.SpatialReference.FactoryCode)
+                SelectedSurfaceSpatialRef = geoDataset.SpatialReference;
+
+                if (SelectedSurfaceSpatialRef is IGeographicCoordinateSystem)
                 {
                     MessageBox.Show(VisibilityLibrary.Properties.Resources.LLOSUserPrompt, VisibilityLibrary.Properties.Resources.LLOSUserPromptCaption);
                     return;

--- a/source/Visibility/VisibilityLibrary/Properties/Resources.Designer.cs
+++ b/source/Visibility/VisibilityLibrary/Properties/Resources.Designer.cs
@@ -574,7 +574,7 @@ namespace VisibilityLibrary.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Spatial Reference of Data Frame and surface must match.  Please change the Spatial Reference of the Data Frame and try again..
+        ///   Looks up a localized string similar to The selected surface has not been projected.  Please project your data and try again..
         /// </summary>
         public static string LLOSUserPrompt {
             get {
@@ -583,7 +583,7 @@ namespace VisibilityLibrary.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unmatched Spatial References.
+        ///   Looks up a localized string similar to Surface Projection.
         /// </summary>
         public static string LLOSUserPromptCaption {
             get {

--- a/source/Visibility/VisibilityLibrary/Properties/Resources.resx
+++ b/source/Visibility/VisibilityLibrary/Properties/Resources.resx
@@ -301,10 +301,10 @@
     <value>Target Map Point Tool</value>
   </data>
   <data name="LLOSUserPrompt" xml:space="preserve">
-    <value>Spatial Reference of Data Frame and surface must match.  Please change the Spatial Reference of the Data Frame and try again.</value>
+    <value>The selected surface has not been projected.  Please project your data and try again.</value>
   </data>
   <data name="LLOSUserPromptCaption" xml:space="preserve">
-    <value>Unmatched Spatial References</value>
+    <value>Surface Projection</value>
   </data>
   <data name="RLOSUserPrompt" xml:space="preserve">
     <value>The selected surface has not been projected.  Please project your data and try again.</value>


### PR DESCRIPTION
…data frame

Fixed issue where LLOS projection was being tested for comparison of
data frame.  The same message is now displayed for LLOS as RLOS message
when input surface is not projected.

Related to issue #118 

@jmhauck please review and merge.