### PR TITLE
Fix for Issue 146

### DIFF
--- a/source/Visibility/ProAppVisibilityModule/ViewModels/ProLOSBaseViewModel.cs
+++ b/source/Visibility/ProAppVisibilityModule/ViewModels/ProLOSBaseViewModel.cs
@@ -59,6 +59,7 @@ namespace ProAppVisibilityModule.ViewModels
             LayersAddedEvent.Subscribe(OnLayersAdded);
             LayersRemovedEvent.Subscribe(OnLayersAdded);
             MapPropertyChangedEvent.Subscribe(OnMapPropertyChanged);
+            MapMemberPropertiesChangedEvent.Subscribe(OnMapMemberPropertyChanged);
         }
 
         ~ProLOSBaseViewModel()
@@ -562,6 +563,13 @@ namespace ProAppVisibilityModule.ViewModels
         private async void OnMapPropertyChanged(MapPropertyChangedEventArgs obj)
         {
             await ResetSurfaceNames();
+        }
+
+        private async void OnMapMemberPropertyChanged(MapMemberPropertiesChangedEventArgs obj)
+        {
+            IEnumerable<MapMemberEventHint> mapMemberHint = obj.EventHints;
+            if (mapMemberHint.ElementAt(0).ToString() == "Name")
+                await ResetSurfaceNames();
         }
 
 


### PR DESCRIPTION
Fix for issue #146 when layer name is changed in contents pane,
Visibility tool now catches that event and updates the name in the
Surface dropdown.

@kgonzago please review and merge