### PR TITLE
Changed Height to Height Above Surface

### DIFF
--- a/source/Visibility/VisibilityLibrary/Properties/Resources.Designer.cs
+++ b/source/Visibility/VisibilityLibrary/Properties/Resources.Designer.cs
@@ -457,7 +457,7 @@ namespace VisibilityLibrary.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Height.
+        ///   Looks up a localized string similar to Height Above Surface.
         /// </summary>
         public static string LabelOffsets {
             get {

--- a/source/Visibility/VisibilityLibrary/Properties/Resources.resx
+++ b/source/Visibility/VisibilityLibrary/Properties/Resources.resx
@@ -229,7 +229,7 @@
     <value>Observer Points</value>
   </data>
   <data name="LabelOffsets" xml:space="preserve">
-    <value>Height</value>
+    <value>Height Above Surface</value>
   </data>
   <data name="LabelOK" xml:space="preserve">
     <value>OK</value>


### PR DESCRIPTION
Sorry about the double PR ( #195 and this) - Changed to "Height Above Surface" to be consistent with GP Tools #156 - see: https://github.com/Esri/visibility-addin-dotnet/issues/156#issuecomment-303149754