### PR TITLE
Dark mode points list box issue

### DIFF
--- a/source/Visibility/VisibilityLibrary/MAResourceDictionary.xaml
+++ b/source/Visibility/VisibilityLibrary/MAResourceDictionary.xaml
@@ -86,6 +86,10 @@
             </DataTrigger>
         </Style.Triggers>
     </Style>
+    <Style x:Key="listboxItemStyle" TargetType="ListBoxItem">
+        <Setter Property="Foreground" Value="Black" />
+        <Setter Property="Background" Value="White" />
+    </Style>
     <Style x:Key="listboxStyle" TargetType="ListBox">
         <Setter Property="IsEnabled" Value="True" />
         <Style.Triggers>

--- a/source/Visibility/VisibilityLibrary/Views/LLOSView.xaml
+++ b/source/Visibility/VisibilityLibrary/Views/LLOSView.xaml
@@ -15,7 +15,6 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="/VisibilityLibrary;component/MAResourceDictionary.xaml" />
             </ResourceDictionary.MergedDictionaries>
-
             <BooleanToVisibilityConverter x:Key="BoolToVis" />
         </ResourceDictionary>
     </UserControl.Resources>
@@ -130,7 +129,8 @@
                     PreviewMouseRightButtonDown="listBoxObservers_PreviewMouseRightButtonDown"
                     ScrollViewer.VerticalScrollBarVisibility="Visible"
                     SelectionMode="Multiple"
-                    Style="{StaticResource listboxStyle}">
+                    Style="{StaticResource listboxStyle}"
+                    ItemContainerStyle="{StaticResource listboxItemStyle}">
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <StackPanel Orientation="Horizontal">
@@ -212,7 +212,8 @@
                     PreviewMouseRightButtonDown="listBoxTargets_PreviewMouseRightButtonDown"
                     ScrollViewer.VerticalScrollBarVisibility="Visible"
                     SelectionMode="Multiple"
-                    Style="{StaticResource listboxStyle}">
+                    Style="{StaticResource listboxStyle}"
+                    ItemContainerStyle="{StaticResource listboxItemStyle}">
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <StackPanel Orientation="Horizontal">

--- a/source/Visibility/VisibilityLibrary/Views/RLOSView.xaml
+++ b/source/Visibility/VisibilityLibrary/Views/RLOSView.xaml
@@ -139,7 +139,8 @@
                     ItemsSource="{Binding ObserverAddInPoints}"
                     PreviewMouseRightButtonDown="ListBox_PreviewMouseRightButtonDown"
                     ScrollViewer.VerticalScrollBarVisibility="Visible"
-                    SelectionMode="Multiple">
+                    SelectionMode="Multiple"
+                    ItemContainerStyle="{StaticResource listboxItemStyle}">
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <StackPanel Orientation="Horizontal">


### PR DESCRIPTION
Opening this PR in case needed. Not sure if it is just me and my windows theme, but the observer/target points were not showing up in Dark Mode. 

Can someone test this @ACueva @NatalieCampos @dfoll  - and then merge this PR if it is repeatable?

Light:
![image](https://cloud.githubusercontent.com/assets/3090809/26464856/2ed3ff68-4157-11e7-95c9-68108aeddab0.png)


Dark Mode (after the fix in this PR):
![image](https://cloud.githubusercontent.com/assets/3090809/26464653/8e1cc910-4156-11e7-91ae-34baae098169.png)
