### PR TITLE
Error while testing Viewshed.py

### DIFF
--- a/source/widget/Visibility/gpservices/Viewshed/Viewshed.py
+++ b/source/widget/Visibility/gpservices/Viewshed/Viewshed.py
@@ -180,7 +180,7 @@ def main():
     Extent = str(xMin) + " " + str(yMin) + " " + str(xMax) + " " + str(yMax)
     # Call image service a second time to get corrected extents
     arcpy.env.extent = Extent
-    arcpy.env.mask = "in_memory\\OutBuffer"
+    arcpy.env.mask = "in_memory\\OuterBuffer"
     arcpy.AddMessage("Clipping image to observer buffer...")
     # arcpy.MakeImageServerLayer_management(elevation, "elevation", Extent, "#", "#", "#", "#", "#", elevDesc.meanCellWidth)
     arcpy.Clip_management(elevation, Extent, "in_memory\clip")


### PR DESCRIPTION
While testing #222 got this error on 10.6

Typo in name gives this error on newer versions of ArcGIS desktop

```
ExecuteError: ERROR 010161: Unable to open the mask raster in_memory\OutBuffer.
```