### PR TITLE
Renamed whilst to while

### DIFF
--- a/source/widget/Visibility/nls/strings.js
+++ b/source/widget/Visibility/nls/strings.js
@@ -12,7 +12,7 @@ define({
     "maxObsDistance": "Max Observable Distance",
     "taskURLError": "The widget configuration file contains a URL that is unreachable. Please check with your system administrator",
     "taskURLInvalid": "The geoprocessing task configured with this widget is not valid. Please check with your system administrator",
-    "viewshedError": "An error occured whilst creating visibility. Please ensure your observer location falls within the extent of your elevation surface.</p>",
+    "viewshedError": "An error occured while creating visibility. Please ensure your observer location falls within the extent of your elevation surface.</p>",
     "validationError": "<p>The visibility creation form has missing or invalid parameters, Please ensure:</p><ul><li>An observer location has been set.</li><li>The observer Field of View is not 0.</li><li>The observer height contains a valid value.</li><li>The min and max observable distances contain valid values.</li></ul>",
     "comfirmInputNotation": "Confirm Input Notation",
     "notationsMatch": "notations match your input please confirm which you would like to use:",


### PR DESCRIPTION
The word "whilst" was still referenced in the NLS/string.js file. Renamed that word to "while".