### PR TITLE
Visibility Addin DotNet – Sprint 1 & 2 of 3

### DIFF
--- a/source/addins/ArcMapAddinVisibility/ViewModels/LLOSViewModel.cs
+++ b/source/addins/ArcMapAddinVisibility/ViewModels/LLOSViewModel.cs
@@ -37,14 +37,28 @@ namespace ArcMapAddinVisibility.ViewModels
         public LLOSViewModel()
         {
             TargetAddInPoints = new ObservableCollection<AddInPoint>();
-
+            DisplayProgressBarLLOS = Visibility.Hidden;
             // commands
             SubmitCommand = new RelayCommand(OnSubmitCommand);
 
             ClearGraphicsVisible = true;
+            
         }
 
         #region Properties
+        private Visibility _displayProgressBarLLOS;
+        public Visibility DisplayProgressBarLLOS
+        {
+            get
+            {
+                return _displayProgressBarLLOS;
+            }
+            set
+            {
+                _displayProgressBarLLOS = value;
+                RaisePropertyChanged(() => DisplayProgressBarLLOS);
+            }
+        }
 
         public ObservableCollection<AddInPoint> TargetAddInPoints { get; set; }
 
@@ -63,9 +77,9 @@ namespace ArcMapAddinVisibility.ViewModels
             var savedCursor = System.Windows.Forms.Cursor.Current;
             System.Windows.Forms.Cursor.Current = System.Windows.Forms.Cursors.WaitCursor;
             System.Windows.Forms.Application.DoEvents();
-
+            DisplayProgressBarLLOS = Visibility.Visible;
             CreateMapElement();
-
+            DisplayProgressBarLLOS = Visibility.Hidden;
             System.Windows.Forms.Cursor.Current = savedCursor;
         }
 

--- a/source/addins/ArcMapAddinVisibility/ViewModels/LLOSViewModel.cs
+++ b/source/addins/ArcMapAddinVisibility/ViewModels/LLOSViewModel.cs
@@ -45,19 +45,6 @@ namespace ArcMapAddinVisibility.ViewModels
         }
 
         #region Properties
-        private Visibility _displayProgressBarLLOS;
-        public Visibility DisplayProgressBarLLOS
-        {
-            get
-            {
-                return _displayProgressBarLLOS;
-            }
-            set
-            {
-                _displayProgressBarLLOS = value;
-                RaisePropertyChanged(() => DisplayProgressBarLLOS);
-            }
-        }
 
         public ObservableCollection<AddInPoint> TargetAddInPoints { get; set; }
 

--- a/source/addins/ArcMapAddinVisibility/ViewModels/LLOSViewModel.cs
+++ b/source/addins/ArcMapAddinVisibility/ViewModels/LLOSViewModel.cs
@@ -37,7 +37,6 @@ namespace ArcMapAddinVisibility.ViewModels
         public LLOSViewModel()
         {
             TargetAddInPoints = new ObservableCollection<AddInPoint>();
-            DisplayProgressBarLLOS = Visibility.Hidden;
             // commands
             SubmitCommand = new RelayCommand(OnSubmitCommand);
 
@@ -77,9 +76,7 @@ namespace ArcMapAddinVisibility.ViewModels
             var savedCursor = System.Windows.Forms.Cursor.Current;
             System.Windows.Forms.Cursor.Current = System.Windows.Forms.Cursors.WaitCursor;
             System.Windows.Forms.Application.DoEvents();
-            DisplayProgressBarLLOS = Visibility.Visible;
             CreateMapElement();
-            DisplayProgressBarLLOS = Visibility.Hidden;
             System.Windows.Forms.Cursor.Current = savedCursor;
         }
 

--- a/source/addins/ArcMapAddinVisibility/ViewModels/LOSBaseViewModel.cs
+++ b/source/addins/ArcMapAddinVisibility/ViewModels/LOSBaseViewModel.cs
@@ -257,7 +257,7 @@ namespace ArcMapAddinVisibility.ViewModels
                     using (Stream s = new FileStream(fileDialog.FileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                     {
                         var lists = CoordinateConversionLibrary.Helpers.ImportCSV.Import<CoordinateConversionLibrary.ViewModels.ImportCoordinatesList>(s, fieldVM.SelectedFields.ToArray());
-                          
+
                         foreach (var item in lists)
                         {
                             string outFormattedString = string.Empty;
@@ -269,17 +269,24 @@ namespace ArcMapAddinVisibility.ViewModels
                             string coordinate = sb.ToString();
                             CoordinateConversionLibrary.Models.CoordinateType ccType = CoordinateConversionLibrary.Helpers.ConversionUtils.GetCoordinateString(coordinate, out outFormattedString);
                             IPoint point = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetPointFromString(outFormattedString) : null;
-                            if (mode == VisibilityLibrary.Properties.Resources.ToolModeObserver)
+                            if (point != null)
                             {
-                                ToolMode = MapPointToolMode.Observer;
-                                Point1 = point; 
-                                OnNewMapPointEvent(Point1);
-                            }
-                            else if (mode == VisibilityLibrary.Properties.Resources.ToolModeTarget)
-                            {
-                                ToolMode = MapPointToolMode.Target;
-                                Point2 = point; 
-                                OnNewMapPointEvent(Point2);
+                                if (mode == VisibilityLibrary.Properties.Resources.ToolModeObserver)
+                                {
+                                    ToolMode = MapPointToolMode.Observer;
+                                    Point1 = point;
+                                    if ((ArcMap.Document != null) && (ArcMap.Document.FocusMap != null))
+                                        point.Project(ArcMap.Document.FocusMap.SpatialReference);
+                                    OnNewMapPointEvent(Point1);
+                                }
+                                else if (mode == VisibilityLibrary.Properties.Resources.ToolModeTarget)
+                                {
+                                    ToolMode = MapPointToolMode.Target;
+                                    Point2 = point;
+                                    if ((ArcMap.Document != null) && (ArcMap.Document.FocusMap != null))
+                                        point.Project(ArcMap.Document.FocusMap.SpatialReference);
+                                    OnNewMapPointEvent(Point2);
+                                }
                             }
                         }
                     }
@@ -307,20 +314,29 @@ namespace ArcMapAddinVisibility.ViewModels
                 string coordinate = item.Trim().ToString();
                 CoordinateConversionLibrary.Models.CoordinateType ccType = CoordinateConversionLibrary.Helpers.ConversionUtils.GetCoordinateString(coordinate, out outFormattedString);
                 IPoint point = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetPointFromString(outFormattedString) : null;
-                if (mode == VisibilityLibrary.Properties.Resources.ToolModeObserver)
+                if (point != null)
                 {
-                    ToolMode = MapPointToolMode.Observer;
-                    Point1 = point; OnNewMapPointEvent(Point1);
+                    if (mode == VisibilityLibrary.Properties.Resources.ToolModeObserver)
+                    {
+                        ToolMode = MapPointToolMode.Observer;
+                        Point1 = point;
+                        if ((ArcMap.Document != null) && (ArcMap.Document.FocusMap != null))
+                            point.Project(ArcMap.Document.FocusMap.SpatialReference);
+                        OnNewMapPointEvent(Point1);
+                    }
+                    else if (mode == VisibilityLibrary.Properties.Resources.ToolModeTarget)
+                    {
+                        ToolMode = MapPointToolMode.Target;
+                        Point2 = point;
+                        if ((ArcMap.Document != null) && (ArcMap.Document.FocusMap != null))
+                            point.Project(ArcMap.Document.FocusMap.SpatialReference);
+                        OnNewMapPointEvent(Point2);
+                    }
                 }
-                else if (mode == VisibilityLibrary.Properties.Resources.ToolModeTarget)
-                {
-                    ToolMode = MapPointToolMode.Target;
-                    Point2 = point; OnNewMapPointEvent(Point2);
-                }
-            }           
+            }
         }
 
-        #endregion
+        #endregion 
 
         #region Event handlers
 

--- a/source/addins/ArcMapAddinVisibility/ViewModels/LOSBaseViewModel.cs
+++ b/source/addins/ArcMapAddinVisibility/ViewModels/LOSBaseViewModel.cs
@@ -26,6 +26,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Windows;
 using VisibilityLibrary;
 using VisibilityLibrary.Helpers;
@@ -268,6 +269,15 @@ namespace ArcMapAddinVisibility.ViewModels
 
                             string coordinate = sb.ToString();
                             CoordinateConversionLibrary.Models.CoordinateType ccType = CoordinateConversionLibrary.Helpers.ConversionUtils.GetCoordinateString(coordinate, out outFormattedString);
+                            if (ccType == CoordinateConversionLibrary.Models.CoordinateType.Unknown)
+                            {
+                                Regex regexMercator = new Regex(@"^(?<latitude>\-?\d+\.?\d*)[+,;:\s]*(?<longitude>\-?\d+\.?\d*)");
+                                var matchMercator = regexMercator.Match(coordinate);
+                                if (matchMercator.Success && matchMercator.Length == coordinate.Length)
+                                {
+                                    ccType = CoordinateType.DD; 
+                                }
+                            }
                             IPoint point = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetPointFromString(outFormattedString) : null;
                             if (point != null)
                             {
@@ -313,6 +323,15 @@ namespace ArcMapAddinVisibility.ViewModels
                 string outFormattedString = string.Empty;
                 string coordinate = item.Trim().ToString();
                 CoordinateConversionLibrary.Models.CoordinateType ccType = CoordinateConversionLibrary.Helpers.ConversionUtils.GetCoordinateString(coordinate, out outFormattedString);
+                if (ccType == CoordinateConversionLibrary.Models.CoordinateType.Unknown)
+                {
+                    Regex regexMercator = new Regex(@"^(?<latitude>\-?\d+\.?\d*)[+,;:\s]*(?<longitude>\-?\d+\.?\d*)");
+                    var matchMercator = regexMercator.Match(coordinate);
+                    if (matchMercator.Success && matchMercator.Length == coordinate.Length)
+                    {
+                        ccType = CoordinateType.DD;
+                    }
+                }
                 IPoint point = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetPointFromString(outFormattedString) : null;
                 if (point != null)
                 {
@@ -336,7 +355,7 @@ namespace ArcMapAddinVisibility.ViewModels
             }
         }
 
-        #endregion 
+        #endregion
 
         #region Event handlers
 

--- a/source/addins/ArcMapAddinVisibility/ViewModels/LOSBaseViewModel.cs
+++ b/source/addins/ArcMapAddinVisibility/ViewModels/LOSBaseViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Esri
+﻿// Copyright 2016 Esri 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -246,12 +246,20 @@ namespace ArcMapAddinVisibility.ViewModels
                 using (Stream s = new FileStream(fileDialog.FileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                 {
                     var headers = CoordinateConversionLibrary.Helpers.ImportCSV.GetHeaders(s);
-                    foreach (var header in headers)
+                    if (headers != null)
                     {
-                        fieldVM.AvailableFields.Add(header);
-                        System.Diagnostics.Debug.WriteLine("header : {0}", header);
+                        foreach (var header in headers)
+                        {
+                            fieldVM.AvailableFields.Add(header);
+                            System.Diagnostics.Debug.WriteLine("header : {0}", header);
+                        }
+                        dlg.DataContext = fieldVM;
                     }
-                    dlg.DataContext = fieldVM;
+                    else
+                    {
+                        System.Windows.Forms.MessageBox.Show(VisibilityLibrary.Properties.Resources.MsgNoDataFound);
+                        return;
+                    }
                 }
                 if (dlg.ShowDialog() == true)
                 {
@@ -275,7 +283,7 @@ namespace ArcMapAddinVisibility.ViewModels
                                 var matchMercator = regexMercator.Match(coordinate);
                                 if (matchMercator.Success && matchMercator.Length == coordinate.Length)
                                 {
-                                    ccType = CoordinateType.DD; 
+                                    ccType = CoordinateType.DD;
                                 }
                             }
                             IPoint point = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetPointFromString(outFormattedString) : null;
@@ -754,7 +762,7 @@ namespace ArcMapAddinVisibility.ViewModels
         }
 
         /// <summary>
-        /// Method used to reset the currently selected surfacename
+        /// Method used to reset the currently selected surfacename 
         /// Use when toc items or map changes, on tab selection changed, etc
         /// </summary>
         /// <param name="map">IMap</param>

--- a/source/addins/ArcMapAddinVisibility/ViewModels/RLOSViewModel.cs
+++ b/source/addins/ArcMapAddinVisibility/ViewModels/RLOSViewModel.cs
@@ -427,18 +427,18 @@ namespace ArcMapAddinVisibility.ViewModels
                     //unit of raster
                     DistanceTypes srUnit = GetMTUnitFromEsriUnit(unitString);
                     //get distance in map units
-                    double muMaxDist = GetDistanceFromTo(OffsetUnitType, srUnit, MaxDistance);
-                    double muMinDist = GetDistanceFromTo(OffsetUnitType, srUnit, MinDistance);
+                    double muMaxDist = GetDistanceFromTo(DistanceUnitType, srUnit, MaxDistance);
+                    double muMinDist = GetDistanceFromTo(DistanceUnitType, srUnit, MinDistance);
                     //Distance in meters
                     double convertedMinDistance = MinDistance * conversionFactor;
                     double convertedMaxDistance = MaxDistance * conversionFactor;
 
                     double finalMinDistance;
                     double finalMaxDistance;
-                    if (srUnit.ToString() != OffsetUnitType.ToString())
+                    if (srUnit.ToString() != DistanceUnitType.ToString())
                     {
-                        finalMinDistance = GetLinearDistance(ArcMap.Document.FocusMap, convertedMinDistance, OffsetUnitType);
-                        finalMaxDistance = GetLinearDistance(ArcMap.Document.FocusMap, convertedMaxDistance, OffsetUnitType);
+                        finalMinDistance = GetLinearDistance(ArcMap.Document.FocusMap, convertedMinDistance, DistanceUnitType);
+                        finalMaxDistance = GetLinearDistance(ArcMap.Document.FocusMap, convertedMaxDistance, DistanceUnitType);
                     }
                     else
                     {

--- a/source/addins/ProAppVisibilityModule/ProAppVisibilityModule.csproj
+++ b/source/addins/ProAppVisibilityModule/ProAppVisibilityModule.csproj
@@ -114,6 +114,10 @@
     <Compile Include="Views\ProEditPropertiesView.xaml.cs">
       <DependentUpon>ProEditPropertiesView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\ProSelectCoordinateFieldsView.xaml.cs">
+      <DependentUpon>ProSelectCoordinateFieldsView.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="VisibilityMapTool.cs" />
     <Compile Include="PropertiesButton.cs" />
     <Compile Include="VisibilityDockpane.xaml.cs">
@@ -127,6 +131,10 @@
     <Page Include="Views\ProEditPropertiesView.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views\ProSelectCoordinateFieldsView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="VisibilityDockpane.xaml">
       <SubType>Designer</SubType>
@@ -180,9 +188,10 @@
     </XmlPeek>
     <Message Importance="High" Text="old build number @(Peeked) new build number $(BUILD_MAJOR).$(BUILD_MINOR).$(BUILD_PATCH).$(BUILD_NUMBER)" />
     <XmlPoke XmlInputPath="Config.daml" Query="//@version[1]" Value="$(BUILD_MAJOR).$(BUILD_MINOR).$(BUILD_PATCH).$(BUILD_NUMBER)" />
-    <XmlPeek XmlInputPath="Config.daml" Query="/x:ArcGIS/x:AddInInfo/x:Date/text()" Namespaces="&lt;Namespace Prefix='x' Uri='http://schemas.esri.com/DADF/Registry' /&gt;"> <Output TaskParameter="Result" ItemName="Peeked_Date" />
+    <XmlPeek XmlInputPath="Config.daml" Query="/x:ArcGIS/x:AddInInfo/x:Date/text()" Namespaces="&lt;Namespace Prefix='x' Uri='http://schemas.esri.com/DADF/Registry' /&gt;">
+      <Output TaskParameter="Result" ItemName="Peeked_Date" />
     </XmlPeek>
     <Message Importance="High" Text="Old build date @(Peeked_Date) New build date $(BUILD_DATE)" />
-    <XmlPoke XmlInputPath="Config.daml" Query="/x:ArcGIS/x:AddInInfo/x:Date" Namespaces="&lt;Namespace Prefix='x' Uri='http://schemas.esri.com/DADF/Registry' /&gt;" Value="$(BUILD_DATE)"/>
+    <XmlPoke XmlInputPath="Config.daml" Query="/x:ArcGIS/x:AddInInfo/x:Date" Namespaces="&lt;Namespace Prefix='x' Uri='http://schemas.esri.com/DADF/Registry' /&gt;" Value="$(BUILD_DATE)" />
   </Target>
 </Project>

--- a/source/addins/ProAppVisibilityModule/ViewModels/ProLLOSViewModel.cs
+++ b/source/addins/ProAppVisibilityModule/ViewModels/ProLLOSViewModel.cs
@@ -41,7 +41,7 @@ namespace ProAppVisibilityModule.ViewModels
         {
             TargetAddInPoints = new ObservableCollection<AddInPoint>();
             IsActiveTab = true;
-
+            DisplayProgressBarLLOS = Visibility.Hidden;
             // commands
             SubmitCommand = new RelayCommand(async (obj) => 
             {
@@ -119,6 +119,20 @@ namespace ProAppVisibilityModule.ViewModels
             set { }
         }
 
+        private Visibility _displayProgressBar = Visibility.Collapsed;
+        public Visibility DisplayProgressBarLLOS
+        {
+            get
+            {
+                return _displayProgressBar;
+            }
+            set
+            {
+                _displayProgressBar = value;
+                RaisePropertyChanged(() => DisplayProgressBarLLOS);
+            }
+        }
+
         #endregion
 
         #region Commands
@@ -139,13 +153,17 @@ namespace ProAppVisibilityModule.ViewModels
                         // TODO udpate wait cursor/progressor
                         try
                         {
+                            DisplayProgressBarLLOS = Visibility.Visible;
                             await CreateMapElement();
-
                             //await Reset(true);
                         }
                         catch(Exception ex)
                         {
                             Debug.Print(ex.Message);
+                        }
+                        finally
+                        {
+                            DisplayProgressBarLLOS = Visibility.Hidden;
                         }
 
                     });

--- a/source/addins/ProAppVisibilityModule/ViewModels/ProLOSBaseViewModel.cs
+++ b/source/addins/ProAppVisibilityModule/ViewModels/ProLOSBaseViewModel.cs
@@ -26,6 +26,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
 using VisibilityLibrary;
@@ -271,6 +272,15 @@ namespace ProAppVisibilityModule.ViewModels
 
                             string coordinate = sb.ToString();
                             CoordinateConversionLibrary.Models.CoordinateType ccType = CoordinateConversionLibrary.Helpers.ConversionUtils.GetCoordinateString(coordinate, out outFormattedString);
+                            if (ccType == CoordinateConversionLibrary.Models.CoordinateType.Unknown)
+                            {
+                                Regex regexMercator = new Regex(@"^(?<latitude>\-?\d+\.?\d*)[+,;:\s]*(?<longitude>\-?\d+\.?\d*)");
+                                var matchMercator = regexMercator.Match(coordinate);
+                                if (matchMercator.Success && matchMercator.Length == coordinate.Length)
+                                {
+                                    ccType = CoordinateConversionLibrary.Models.CoordinateType.DD;
+                                }
+                            }
                             MapPoint point = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetMapPointFromString(outFormattedString) : null;
                             if (point != null)
                             {
@@ -308,6 +318,15 @@ namespace ProAppVisibilityModule.ViewModels
                 string outFormattedString = string.Empty;
                 string coordinate = item.Trim().ToString();
                 CoordinateConversionLibrary.Models.CoordinateType ccType = CoordinateConversionLibrary.Helpers.ConversionUtils.GetCoordinateString(coordinate, out outFormattedString);
+                if (ccType == CoordinateConversionLibrary.Models.CoordinateType.Unknown)
+                {
+                    Regex regexMercator = new Regex(@"^(?<latitude>\-?\d+\.?\d*)[+,;:\s]*(?<longitude>\-?\d+\.?\d*)");
+                    var matchMercator = regexMercator.Match(coordinate);
+                    if (matchMercator.Success && matchMercator.Length == coordinate.Length)
+                    {
+                        ccType = CoordinateConversionLibrary.Models.CoordinateType.DD;
+                    }
+                }
                 MapPoint point = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetMapPointFromString(outFormattedString) : null;
                 if (point != null)
                 {

--- a/source/addins/ProAppVisibilityModule/ViewModels/ProLOSBaseViewModel.cs
+++ b/source/addins/ProAppVisibilityModule/ViewModels/ProLOSBaseViewModel.cs
@@ -227,7 +227,7 @@ namespace ProAppVisibilityModule.ViewModels
             dlg.DataContext = new EditPropertiesViewModel();
 
             dlg.ShowDialog();
-        }      
+        }
 
         public virtual void OnImportCSVFileCommand(object obj)
         {
@@ -258,7 +258,7 @@ namespace ProAppVisibilityModule.ViewModels
                 {
                     using (Stream s = new FileStream(fileDialog.FileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                     {
-                        var lists = CoordinateConversionLibrary.Helpers.ImportCSV.Import<CoordinateConversionLibrary.ViewModels.ImportCoordinatesList>(s, fieldVM.SelectedFields.ToArray());                   
+                        var lists = CoordinateConversionLibrary.Helpers.ImportCSV.Import<CoordinateConversionLibrary.ViewModels.ImportCoordinatesList>(s, fieldVM.SelectedFields.ToArray());
 
                         foreach (var item in lists)
                         {
@@ -272,18 +272,20 @@ namespace ProAppVisibilityModule.ViewModels
                             string coordinate = sb.ToString();
                             CoordinateConversionLibrary.Models.CoordinateType ccType = CoordinateConversionLibrary.Helpers.ConversionUtils.GetCoordinateString(coordinate, out outFormattedString);
                             MapPoint point = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetMapPointFromString(outFormattedString) : null;
-
-                            if (mode == VisibilityLibrary.Properties.Resources.ToolModeObserver)
+                            if (point != null)
                             {
-                                ToolMode = MapPointToolMode.Observer;
-                                Point1 = point; 
-                                OnNewMapPointEvent(Point1);
-                            }
-                            else if (mode == VisibilityLibrary.Properties.Resources.ToolModeTarget)
-                            {
-                                ToolMode = MapPointToolMode.Target;
-                                Point2 = point; 
-                                OnNewMapPointEvent(Point2);
+                                if (mode == VisibilityLibrary.Properties.Resources.ToolModeObserver)
+                                {
+                                    ToolMode = MapPointToolMode.Observer;
+                                    Point1 = point;
+                                    OnNewMapPointEvent(Point1);
+                                }
+                                else if (mode == VisibilityLibrary.Properties.Resources.ToolModeTarget)
+                                {
+                                    ToolMode = MapPointToolMode.Target;
+                                    Point2 = point;
+                                    OnNewMapPointEvent(Point2);
+                                }
                             }
                         }
                     }
@@ -307,15 +309,20 @@ namespace ProAppVisibilityModule.ViewModels
                 string coordinate = item.Trim().ToString();
                 CoordinateConversionLibrary.Models.CoordinateType ccType = CoordinateConversionLibrary.Helpers.ConversionUtils.GetCoordinateString(coordinate, out outFormattedString);
                 MapPoint point = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetMapPointFromString(outFormattedString) : null;
-                if (mode == VisibilityLibrary.Properties.Resources.ToolModeObserver)
+                if (point != null)
                 {
-                    ToolMode = MapPointToolMode.Observer;
-                    Point1 = point; OnNewMapPointEvent(Point1);
-                }
-                else if (mode == VisibilityLibrary.Properties.Resources.ToolModeTarget)
-                {
-                    ToolMode = MapPointToolMode.Target;
-                    Point2 = point; OnNewMapPointEvent(Point2);
+                    if (mode == VisibilityLibrary.Properties.Resources.ToolModeObserver)
+                    {
+                        ToolMode = MapPointToolMode.Observer;
+                        Point1 = point;
+                        OnNewMapPointEvent(Point1);
+                    }
+                    else if (mode == VisibilityLibrary.Properties.Resources.ToolModeTarget)
+                    {
+                        ToolMode = MapPointToolMode.Target;
+                        Point2 = point;
+                        OnNewMapPointEvent(Point2);
+                    }
                 }
             }
         }

--- a/source/addins/ProAppVisibilityModule/ViewModels/ProRLOSViewModel.cs
+++ b/source/addins/ProAppVisibilityModule/ViewModels/ProRLOSViewModel.cs
@@ -258,7 +258,7 @@ namespace ProAppVisibilityModule.ViewModels
         {
             base.OnDeleteAllPointsCommand(obj);
         }
-
+      
         public override bool CanCreateElement
         {
             get

--- a/source/addins/ProAppVisibilityModule/ViewModels/ProRLOSViewModel.cs
+++ b/source/addins/ProAppVisibilityModule/ViewModels/ProRLOSViewModel.cs
@@ -28,6 +28,7 @@ using ArcGIS.Desktop.Core.Geoprocessing;
 using ArcGIS.Core.Data;
 using ArcGIS.Desktop.Editing;
 using ArcGIS.Desktop.Framework.Threading.Tasks;
+using System.Text.RegularExpressions;
 
 namespace ProAppVisibilityModule.ViewModels
 {
@@ -35,27 +36,47 @@ namespace ProAppVisibilityModule.ViewModels
     {
         #region Properties
 
-        private int executionCounter = 1;
+        private int executionCounter = 0;
         private string _ObserversLayerName = VisibilityLibrary.Properties.Resources.RLOSObserversLayerName;
         public string ObserversLayerName
         {
-            get 
+            get
             {
-                _ObserversLayerName = string.Format("{0}_{1}", VisibilityLibrary.Properties.Resources.RLOSObserversLayerName, executionCounter);
+                if (executionCounter > 0)
+                {
+                    _ObserversLayerName = string.Format("{0}_{1}", VisibilityLibrary.Properties.Resources.RLOSObserversLayerName, executionCounter);
+                }
                 return _ObserversLayerName;
             }
-            set {}
+            set { }
+        }
+
+        private string _FeatureDatasetName = VisibilityLibrary.Properties.Resources.RLOSFeatureDatasetName;
+        public string FeatureDatasetName
+        {
+            get
+            {
+                if (executionCounter > 0)
+                {
+                    _FeatureDatasetName = string.Format("{0}_{1}", VisibilityLibrary.Properties.Resources.RLOSFeatureDatasetName, executionCounter);
+                }
+                return _FeatureDatasetName;
+            }
+            set { }
         }
 
         private string _RLOSConvertedPolygonsLayerName = VisibilityLibrary.Properties.Resources.RLOSConvertedPolygonsLayerName;
         public string RLOSConvertedPolygonsLayerName
         {
-             get 
+            get
             {
-                _RLOSConvertedPolygonsLayerName = string.Format("{0}_{1}", VisibilityLibrary.Properties.Resources.RLOSConvertedPolygonsLayerName, executionCounter);
+                if (executionCounter > 0)
+                {
+                    _RLOSConvertedPolygonsLayerName = string.Format("{0}_{1}", VisibilityLibrary.Properties.Resources.RLOSConvertedPolygonsLayerName, executionCounter);
+                }
                 return _RLOSConvertedPolygonsLayerName;
             }
-            set {}
+            set { }
         }
 
         private string _RLOSOutputLayerName = VisibilityLibrary.Properties.Resources.RLOSOutputLayerName;
@@ -63,7 +84,10 @@ namespace ProAppVisibilityModule.ViewModels
         {
             get
             {
-                _RLOSOutputLayerName = string.Format("{0}_{1}", VisibilityLibrary.Properties.Resources.RLOSOutputLayerName, executionCounter);
+                if (executionCounter > 0)
+                {
+                    _RLOSOutputLayerName = string.Format("{0}_{1}", VisibilityLibrary.Properties.Resources.RLOSOutputLayerName, executionCounter);
+                }
                 return _RLOSOutputLayerName;
             }
             set { }
@@ -74,19 +98,22 @@ namespace ProAppVisibilityModule.ViewModels
         {
             get
             {
-                _RLOSMaskLayerName = string.Format("{0}_{1}", VisibilityLibrary.Properties.Resources.RLOSMaskLayerName, executionCounter);
+                if (executionCounter > 0)
+                {
+                    _RLOSMaskLayerName = string.Format("{0}_{1}", VisibilityLibrary.Properties.Resources.RLOSMaskLayerName, executionCounter);
+                }
                 return _RLOSMaskLayerName;
             }
             set { }
         }
 
         private double _SurfaceOffset = 0.0;
-        public double SurfaceOffset 
+        public double SurfaceOffset
         {
             get { return _SurfaceOffset; }
             set
             {
-                if(value < 0.0)
+                if (value < 0.0)
                     throw new ArgumentException(VisibilityLibrary.Properties.Resources.AEMustBePositive);
 
                 _SurfaceOffset = value;
@@ -95,15 +122,15 @@ namespace ProAppVisibilityModule.ViewModels
         }
 
         private double _MinDistance = 0.0;
-        public double MinDistance 
+        public double MinDistance
         {
             get { return _MinDistance; }
             set
             {
-                if(value < 0.0)
+                if (value < 0.0)
                     throw new ArgumentException(VisibilityLibrary.Properties.Resources.AEMustBePositive);
 
-                if(value > MaxDistance)
+                if (value > MaxDistance)
                     throw new ArgumentException(VisibilityLibrary.Properties.Resources.AENumMustBeLess);
 
                 _MinDistance = value;
@@ -112,12 +139,12 @@ namespace ProAppVisibilityModule.ViewModels
         }
 
         private double _MaxDistance = 1000.0;
-        public double MaxDistance 
+        public double MaxDistance
         {
             get { return _MaxDistance; }
             set
             {
-                if(value < 0.0)
+                if (value < 0.0)
                     throw new ArgumentException(VisibilityLibrary.Properties.Resources.AEMustBePositive);
 
                 if (value < MinDistance)
@@ -130,7 +157,7 @@ namespace ProAppVisibilityModule.ViewModels
 
         private double _LeftHorizontalFOV = 0.0;
         public double LeftHorizontalFOV
-        { 
+        {
             get { return _LeftHorizontalFOV; }
             set
             {
@@ -144,7 +171,7 @@ namespace ProAppVisibilityModule.ViewModels
             }
         }
         private double _RightHorizontalFOV = 360.0;
-        public double RightHorizontalFOV 
+        public double RightHorizontalFOV
         {
             get { return _RightHorizontalFOV; }
             set
@@ -175,7 +202,7 @@ namespace ProAppVisibilityModule.ViewModels
         }
 
         private double _TopVerticalFOV = 90.0;
-        public double TopVerticalFOV 
+        public double TopVerticalFOV
         {
             get { return _TopVerticalFOV; }
             set
@@ -258,7 +285,7 @@ namespace ProAppVisibilityModule.ViewModels
         {
             base.OnDeleteAllPointsCommand(obj);
         }
-      
+
         public override bool CanCreateElement
         {
             get
@@ -314,7 +341,7 @@ namespace ProAppVisibilityModule.ViewModels
             {
                 // Check surface spatial reference
                 var surfaceSR = await GetSpatialReferenceFromLayer(SelectedSurfaceName);
-                if(surfaceSR == null || !surfaceSR.IsProjected)
+                if (surfaceSR == null || !surfaceSR.IsProjected)
                 {
                     MessageBox.Show(VisibilityLibrary.Properties.Resources.RLOSUserPrompt, VisibilityLibrary.Properties.Resources.RLOSUserPromptCaption);
                     return false;
@@ -334,7 +361,33 @@ namespace ProAppVisibilityModule.ViewModels
                     }
                 }
 
-                success = await FeatureClassHelper.CreateLayer(ObserversLayerName, "POINT", true, true);
+                //Validate Dataframe Spatial reference with surface spatial reference
+                if (MapView.Active.Map.SpatialReference.Wkid != surfaceSR.Wkid)
+                {
+                    MessageBox.Show(VisibilityLibrary.Properties.Resources.LOSDataFrameMatch, VisibilityLibrary.Properties.Resources.LOSSpatialReferenceCaption);
+                    return false;
+                }
+
+                using (Geodatabase geodatabase = new Geodatabase(new FileGeodatabaseConnectionPath(new Uri(CoreModule.CurrentProject.DefaultGeodatabasePath))))
+                {
+                    executionCounter = 0;
+                    var enterpriseDefinitionNames = geodatabase.GetDefinitions<FeatureDatasetDefinition>().Where(i => i.GetName().StartsWith(VisibilityLibrary.Properties.Resources.RLOSFeatureDatasetName)).Select(i => i.GetName()).ToList();
+                    foreach (var defName in enterpriseDefinitionNames)
+                    {
+                        int n;
+                        bool isNumeric = int.TryParse(Regex.Match(defName, @"\d+$").Value, out n);
+                        if (isNumeric)
+                            executionCounter = executionCounter < n ? n : executionCounter;
+                    }
+                    executionCounter = enterpriseDefinitionNames.Count > 0 ? executionCounter + 1 : 0;
+                }
+
+                //Create Feature dataset
+                success = await FeatureClassHelper.CreateFeatureDataset(FeatureDatasetName);
+                if (!success)
+                    return false;
+
+                success = await FeatureClassHelper.CreateLayer(FeatureDatasetName, ObserversLayerName, "POINT", true, true);
                 if (!success)
                     return false;
 
@@ -369,7 +422,7 @@ namespace ProAppVisibilityModule.ViewModels
                 await CreateMask(RLOSMaskLayerName, minDistanceInMapUnits, maxDistanceInMapUnits, horizontalStartAngleInDegrees,
                     horizontalEndAngleInDegrees, surfaceSR);
 
-                string maxRangeMaskFeatureClassName = CoreModule.CurrentProject.DefaultGeodatabasePath + System.IO.Path.DirectorySeparatorChar + RLOSMaskLayerName;
+                string maxRangeMaskFeatureClassName = CoreModule.CurrentProject.DefaultGeodatabasePath + System.IO.Path.DirectorySeparatorChar + FeatureDatasetName + System.IO.Path.DirectorySeparatorChar + RLOSMaskLayerName;
                 var environments = Geoprocessing.MakeEnvironmentArray(mask: maxRangeMaskFeatureClassName, overwriteoutput: true);
 
                 var rlosOutputLayer = CoreModule.CurrentProject.DefaultGeodatabasePath + System.IO.Path.DirectorySeparatorChar + RLOSOutputLayerName;
@@ -387,13 +440,13 @@ namespace ProAppVisibilityModule.ViewModels
                 if (!success)
                     return false;
 
-                var rlosConvertedPolygonsLayer = CoreModule.CurrentProject.DefaultGeodatabasePath + System.IO.Path.DirectorySeparatorChar + RLOSConvertedPolygonsLayerName;
+                var rlosConvertedPolygonsLayer = CoreModule.CurrentProject.DefaultGeodatabasePath + System.IO.Path.DirectorySeparatorChar + FeatureDatasetName + System.IO.Path.DirectorySeparatorChar + RLOSConvertedPolygonsLayerName;
 
                 string rangeFanMaskFeatureClassName = string.Empty;
                 if ((MinDistance > 0) || !((horizontalStartAngleInDegrees == 0.0) && (horizontalEndAngleInDegrees == 360.0)))
                 {
                     string RLOSRangeFanMaskLayerName = "RangeFan_" + RLOSMaskLayerName;
-                    rangeFanMaskFeatureClassName = CoreModule.CurrentProject.DefaultGeodatabasePath + System.IO.Path.DirectorySeparatorChar + RLOSRangeFanMaskLayerName;
+                    rangeFanMaskFeatureClassName = CoreModule.CurrentProject.DefaultGeodatabasePath + System.IO.Path.DirectorySeparatorChar + FeatureDatasetName + System.IO.Path.DirectorySeparatorChar + RLOSRangeFanMaskLayerName;
 
                     await CreateMask(RLOSRangeFanMaskLayerName, minDistanceInMapUnits, maxDistanceInMapUnits, horizontalStartAngleInDegrees,
                         horizontalEndAngleInDegrees, surfaceSR, true);
@@ -405,14 +458,18 @@ namespace ProAppVisibilityModule.ViewModels
 
                 await FeatureClassHelper.CreateUniqueValueRenderer(GetLayerFromMapByName(RLOSConvertedPolygonsLayerName) as FeatureLayer, ShowNonVisibleData, RLOSConvertedPolygonsLayerName);
 
+                await FeatureClassHelper.Delete(RLOSOutputLayerName);
+                //await FeatureClassHelper.Delete(RLOSMaskLayerName);
+
                 // Eventually we will add the new layers to a new group layer for each run
                 // Currently not working in current release of Pro.  
                 // From Roshan Herbert - I just spoke with the Dev who wrote the MoveLayer method. Apparently this a known issue. 
                 //                       We have bug to fix this and plan to fix it in the next release.
                 List<Layer> layerList = new List<Layer>();
                 layerList.Add(GetLayerFromMapByName(ObserversLayerName));
-                //layerList.Add(GetLayerFromMapByName(RLOSConvertedPolygonsLayerName));
-                
+                layerList.Add(GetLayerFromMapByName(RLOSConvertedPolygonsLayerName));
+                await FeatureClassHelper.MoveLayersToGroupLayer(layerList, FeatureDatasetName);
+
                 //string groupName = "RLOS Group";
                 //if (executionCounter > 0)
                 //    groupName = string.Format("{0}_{1}", groupName, executionCounter.ToString());
@@ -429,8 +486,6 @@ namespace ProAppVisibilityModule.ViewModels
                     var envelope = await QueuedTask.Run(() => layer.QueryExtent());
                     await ZoomToExtent(envelope);
                 }
-
-                executionCounter++;
 
                 success = true;
             }
@@ -450,13 +505,13 @@ namespace ProAppVisibilityModule.ViewModels
         /// <param name="maskFeatureClassName"></param>
         /// <param name="bufferDistance"></param>
         /// <returns>Task</returns>
-        private async Task CreateMask(string maskFeatureClassName, 
-            double minDistanceInMapUnits, double maxDistanceInMapUnits, 
-            double horizontalStartAngleInDegrees, double horizontalEndAngleInDegrees, 
+        private async Task CreateMask(string maskFeatureClassName,
+            double minDistanceInMapUnits, double maxDistanceInMapUnits,
+            double horizontalStartAngleInDegrees, double horizontalEndAngleInDegrees,
             SpatialReference surfaceSR, bool constructRangeFans = false)
         {
             // create new
-            await FeatureClassHelper.CreateLayer(maskFeatureClassName, "POLYGON", false, false);
+            await FeatureClassHelper.CreateLayer(FeatureDatasetName, maskFeatureClassName, "POLYGON", false, false);
 
             try
             {
@@ -471,42 +526,42 @@ namespace ProAppVisibilityModule.ViewModels
                         EditOperation editOperation = new EditOperation();
                         editOperation.Callback(context =>
                         {
-                        try
-                        {
-                            var shapeFieldName = fcDefinition.GetShapeField();
-
-                            foreach (var observer in ObserverAddInPoints)
+                            try
                             {
-                                using (var rowBuffer = enterpriseFeatureClass.CreateRowBuffer())
+                                var shapeFieldName = fcDefinition.GetShapeField();
+
+                                foreach (var observer in ObserverAddInPoints)
                                 {
-                                    // Either the field index or the field name can be used in the indexer.
-                                    // project the point here or the buffer tool may use an angular unit and run forever
-                                    var point = GeometryEngine.Instance.Project(observer.Point, surfaceSR);
-                                    Geometry polygon = null;
-
-                                    if (constructRangeFans)
+                                    using (var rowBuffer = enterpriseFeatureClass.CreateRowBuffer())
                                     {
-                                        polygon = GeometryHelper.ConstructRangeFan(point as MapPoint,
-                                            minDistanceInMapUnits, maxDistanceInMapUnits, horizontalStartAngleInDegrees,
-                                            horizontalEndAngleInDegrees, surfaceSR);                                       
-                                    }
-                                    else
-                                    {
-                                        polygon = GeometryEngine.Instance.Buffer(point, maxDistanceInMapUnits);
-                                    }
+                                        // Either the field index or the field name can be used in the indexer.
+                                        // project the point here or the buffer tool may use an angular unit and run forever
+                                        var point = GeometryEngine.Instance.Project(observer.Point, surfaceSR);
+                                        Geometry polygon = null;
 
-                                    rowBuffer[shapeFieldName] = polygon;
+                                        if (constructRangeFans)
+                                        {
+                                            polygon = GeometryHelper.ConstructRangeFan(point as MapPoint,
+                                                minDistanceInMapUnits, maxDistanceInMapUnits, horizontalStartAngleInDegrees,
+                                                horizontalEndAngleInDegrees, surfaceSR);
+                                        }
+                                        else
+                                        {
+                                            polygon = GeometryEngine.Instance.Buffer(point, maxDistanceInMapUnits);
+                                        }
 
-                                    Feature feature = enterpriseFeatureClass.CreateRow(rowBuffer);
-                                    feature.Store();
-                                    context.Invalidate(feature);
-                                } // using
-                            } // for each 
-                        }
-                        catch (GeodatabaseException exObj)
-                        {
-                            message = exObj.Message;
-                        }
+                                        rowBuffer[shapeFieldName] = polygon;
+
+                                        Feature feature = enterpriseFeatureClass.CreateRow(rowBuffer);
+                                        feature.Store();
+                                        context.Invalidate(feature);
+                                    } // using
+                                } // for each 
+                            }
+                            catch (GeodatabaseException exObj)
+                            {
+                                message = exObj.Message;
+                            }
                         }, enterpriseFeatureClass);
 
                         creationResult = await editOperation.ExecuteAsync();

--- a/source/addins/ProAppVisibilityModule/ViewModels/ProTabBaseViewModel.cs
+++ b/source/addins/ProAppVisibilityModule/ViewModels/ProTabBaseViewModel.cs
@@ -580,7 +580,7 @@ namespace ProAppVisibilityModule.ViewModels
                         var Lon = Double.Parse(matchMercator.Groups["longitude"].Value);
                         point = QueuedTask.Run(() =>
                             {
-                                return MapPointBuilder.CreateMapPoint(Lon, Lat);
+                                return MapPointBuilder.CreateMapPoint(Lon, Lat, MapView.Active.Map.SpatialReference);
                             }).Result;
                         return point;
                     }

--- a/source/addins/ProAppVisibilityModule/Views/ProSelectCoordinateFieldsView.xaml
+++ b/source/addins/ProAppVisibilityModule/Views/ProSelectCoordinateFieldsView.xaml
@@ -1,0 +1,79 @@
+<controls:ProWindow  x:Class="CoordinateConversionLibrary.Views.ProSelectCoordinateFieldsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:controls="clr-namespace:ArcGIS.Desktop.Framework.Controls;assembly=ArcGIS.Desktop.Framework"
+             xmlns:extensions="clr-namespace:ArcGIS.Desktop.Extensions;assembly=ArcGIS.Desktop.Extensions"                      
+             xmlns:local="clr-namespace:CoordinateConversionLibrary;assembly=CoordinateConversionLibrary"
+             xmlns:viewModels="clr-namespace:CoordinateConversionLibrary.ViewModels;assembly=CoordinateConversionLibrary"
+             xmlns:prop="clr-namespace:CoordinateConversionLibrary.Properties;assembly=CoordinateConversionLibrary"
+             xmlns:helpers="clr-namespace:CoordinateConversionLibrary.Helpers;assembly=CoordinateConversionLibrary"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
+             mc:Ignorable="d" 
+             WindowStartupLocation="CenterScreen"
+             Title="{x:Static prop:Resources.TitleSelectCoordinateFields}"
+             SizeToContent="WidthAndHeight"
+             helpers:DialogCloser.DialogResult="{Binding DialogResult}"
+                     d:DesignHeight="200" d:DesignWidth="420">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <extensions:DesignOnlyResourceDictionary Source="pack://application:,,,/ArcGIS.Desktop.Framework;component\Themes\Default.xaml"/>
+                <ResourceDictionary Source="/CoordinateConversionLibrary;component/MAResourceDictionary.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+    <Window.Style>
+        <Style TargetType="Window" BasedOn="{StaticResource {x:Type Window}}">
+            <Setter Property="Background" Value="{DynamicResource Esri_DialogFrameBackgroundBrush}"/>
+        </Style>
+    </Window.Style>
+    <StackPanel Margin="20">
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" >
+            <TextBlock Margin="0,0,10,0" Text="{x:Static prop:Resources.LabelField1}" Style="{DynamicResource Esri_TextBlockRegular}" VerticalAlignment="Center" />
+            <ComboBox Height="Auto"
+                      Width="253"
+                      Margin="3,0,0,0"
+                      ItemsSource="{Binding AvailableFields}"
+                      SelectedItem="{Binding SelectedField1}"
+                      ItemContainerStyle="{StaticResource comboBoxItemStyle}">
+            </ComboBox>
+        </StackPanel>
+        <CheckBox x:Name="useTwoFields" Height="Auto" Margin="120,15,0,3" HorizontalAlignment="Left" IsChecked="{Binding UseTwoFields}">
+            <CheckBox.Content>
+                <TextBlock Text="{x:Static prop:Resources.UseTwoFields}" Style="{DynamicResource Esri_TextBlockRegular}" />
+            </CheckBox.Content>
+        </CheckBox>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="0,10,0,5">
+            <StackPanel.Style>
+                <Style TargetType="StackPanel">
+                    <Setter Property="IsEnabled" Value="False" />
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding ElementName=useTwoFields, Path=IsChecked}" Value="True">
+                            <Setter Property="IsEnabled" Value="True" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </StackPanel.Style>
+            <TextBlock Margin="0,0,10,0" Text="{x:Static prop:Resources.LabelField2}" Style="{DynamicResource Esri_TextBlockRegular}"  VerticalAlignment="Center"/>
+            <ComboBox Height="Auto"
+                      Width="253"
+                      Margin="15,0,0,0"
+                      ItemsSource="{Binding AvailableFields}"
+                      SelectedItem="{Binding SelectedField2}"
+                      ItemContainerStyle="{StaticResource comboBoxItemStyle}">
+            </ComboBox>
+        </StackPanel>
+        <StackPanel HorizontalAlignment="Right" Orientation="Horizontal" VerticalAlignment="Bottom">
+            <Button Command="{Binding OKButtonPressedCommand}"
+                    Content="{x:Static prop:Resources.ButtonOK}"
+                    IsCancel="False"
+                    IsEnabled="{Binding IsDialogComplete}" 
+                    Style="{DynamicResource Esri_Button}" />
+            <Button Content="{x:Static prop:Resources.ButtonCancel}"
+                    IsCancel="True" 
+                    Style="{DynamicResource Esri_Button}" />
+        </StackPanel>
+    </StackPanel>
+</controls:ProWindow>

--- a/source/addins/ProAppVisibilityModule/Views/ProSelectCoordinateFieldsView.xaml.cs
+++ b/source/addins/ProAppVisibilityModule/Views/ProSelectCoordinateFieldsView.xaml.cs
@@ -1,0 +1,15 @@
+using ArcGIS.Desktop.Framework.Controls;
+
+namespace CoordinateConversionLibrary.Views
+{
+    /// <summary>
+    /// Interaction logic for ProSelectCoordinateFieldsView.xaml
+    /// </summary>
+    public partial class ProSelectCoordinateFieldsView : ProWindow
+    {
+        public ProSelectCoordinateFieldsView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/source/addins/VisibilityLibrary/Properties/Resources.Designer.cs
+++ b/source/addins/VisibilityLibrary/Properties/Resources.Designer.cs
@@ -412,6 +412,15 @@ namespace VisibilityLibrary.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Import.
+        /// </summary>
+        public static string LabelImport {
+            get {
+                return ResourceManager.GetString("LabelImport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Input Surface.
         /// </summary>
         public static string LabelInputSurface {
@@ -471,6 +480,15 @@ namespace VisibilityLibrary.Properties {
         public static string LabelOK {
             get {
                 return ResourceManager.GetString("LabelOK", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Paste.
+        /// </summary>
+        public static string LabelPaste {
+            get {
+                return ResourceManager.GetString("LabelPaste", resourceCulture);
             }
         }
         

--- a/source/addins/VisibilityLibrary/Properties/Resources.Designer.cs
+++ b/source/addins/VisibilityLibrary/Properties/Resources.Designer.cs
@@ -565,6 +565,15 @@ namespace VisibilityLibrary.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to LLOS.
+        /// </summary>
+        public static string LLOSFeatureDatasetName {
+            get {
+                return ResourceManager.GetString("LLOSFeatureDatasetName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to LLOS_Observers.
         /// </summary>
         public static string LLOSObserversLayerName {
@@ -750,6 +759,15 @@ namespace VisibilityLibrary.Properties {
         public static string RLOSConvertedPolygonsLayerName {
             get {
                 return ResourceManager.GetString("RLOSConvertedPolygonsLayerName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to RLOS.
+        /// </summary>
+        public static string RLOSFeatureDatasetName {
+            get {
+                return ResourceManager.GetString("RLOSFeatureDatasetName", resourceCulture);
             }
         }
         

--- a/source/addins/VisibilityLibrary/Properties/Resources.Designer.cs
+++ b/source/addins/VisibilityLibrary/Properties/Resources.Designer.cs
@@ -700,6 +700,15 @@ namespace VisibilityLibrary.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No data found.
+        /// </summary>
+        public static string MsgNoDataFound {
+            get {
+                return ResourceManager.GetString("MsgNoDataFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Point does not fall within the input extent..
         /// </summary>
         public static string MsgOutOfAOI {

--- a/source/addins/VisibilityLibrary/Properties/Resources.resx
+++ b/source/addins/VisibilityLibrary/Properties/Resources.resx
@@ -417,4 +417,7 @@
   <data name="RLOSFeatureDatasetName" xml:space="preserve">
     <value>RLOS</value>
   </data>
+  <data name="MsgNoDataFound" xml:space="preserve">
+    <value>No data found</value>
+  </data>
 </root>

--- a/source/addins/VisibilityLibrary/Properties/Resources.resx
+++ b/source/addins/VisibilityLibrary/Properties/Resources.resx
@@ -405,4 +405,10 @@
   <data name="MsgSurfaceLayerNotFound" xml:space="preserve">
     <value>The surface layer was not found. Please try again.</value>
   </data>
+  <data name="LabelImport" xml:space="preserve">
+    <value>Import</value>
+  </data>
+  <data name="LabelPaste" xml:space="preserve">
+    <value>Paste</value>
+  </data>
 </root>

--- a/source/addins/VisibilityLibrary/Properties/Resources.resx
+++ b/source/addins/VisibilityLibrary/Properties/Resources.resx
@@ -411,4 +411,10 @@
   <data name="LabelPaste" xml:space="preserve">
     <value>Paste</value>
   </data>
+  <data name="LLOSFeatureDatasetName" xml:space="preserve">
+    <value>LLOS</value>
+  </data>
+  <data name="RLOSFeatureDatasetName" xml:space="preserve">
+    <value>RLOS</value>
+  </data>
 </root>

--- a/source/addins/VisibilityLibrary/Views/LLOSView.xaml
+++ b/source/addins/VisibilityLibrary/Views/LLOSView.xaml
@@ -44,6 +44,14 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
+                 <ProgressBar
+                    Name="pbStatus"
+                    Grid.ColumnSpan="3"
+                    Width="Auto"
+                    Margin="3,3,0,0"
+                    HorizontalAlignment="Stretch"
+                    IsIndeterminate="True"
+                    Visibility="{Binding DisplayProgressBarLLOS}" />
                 <TextBlock
                     Grid.ColumnSpan="3"
                     Margin="3,3,0,0"

--- a/source/addins/VisibilityLibrary/Views/LLOSView.xaml
+++ b/source/addins/VisibilityLibrary/Views/LLOSView.xaml
@@ -44,7 +44,7 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
-                 <ProgressBar
+                <ProgressBar
                     Name="pbStatus"
                     Grid.ColumnSpan="3"
                     Width="Auto"
@@ -143,7 +143,15 @@
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                     <ListBox.ContextMenu>
-                        <ContextMenu DataContext="{Binding Path=PlacementTarget, RelativeSource={RelativeSource Self}}">
+                        <ContextMenu DataContext="{Binding Path=PlacementTarget, RelativeSource={RelativeSource Self}}">                           
+                            <MenuItem
+                                Command="{Binding DataContext.ImportCSVFileCommand}"
+                                CommandParameter="{x:Static prop:Resources.ToolModeObserver}"
+                                Header="{x:Static prop:Resources.LabelImport}"/>
+                            <MenuItem
+                                Command="{Binding DataContext.PasteCoordinatesCommand}"
+                                CommandParameter="{x:Static prop:Resources.ToolModeObserver}"
+                                Header="{x:Static prop:Resources.LabelPaste}"/>
                             <MenuItem
                                 Command="{Binding DataContext.DeletePointCommand}"
                                 CommandParameter="{Binding Path=SelectedItems}"
@@ -151,7 +159,7 @@
                             <MenuItem
                                 Command="{Binding DataContext.DeleteAllPointsCommand}"
                                 CommandParameter="{x:Static prop:Resources.ToolModeObserver}"
-                                Header="{x:Static prop:Resources.MenuLabelDeleteAll}" />
+                                Header="{x:Static prop:Resources.MenuLabelDeleteAll}" />                                                      
                         </ContextMenu>
                     </ListBox.ContextMenu>
                     <ListBox.InputBindings>
@@ -228,13 +236,21 @@
                     <ListBox.ContextMenu>
                         <ContextMenu DataContext="{Binding Path=PlacementTarget, RelativeSource={RelativeSource Self}}">
                             <MenuItem
+                                Command="{Binding DataContext.ImportCSVFileCommand}"
+                                CommandParameter="{x:Static prop:Resources.ToolModeTarget}"
+                                Header="{x:Static prop:Resources.LabelImport}"/>
+                            <MenuItem
+                                Command="{Binding DataContext.PasteCoordinatesCommand}"
+                                CommandParameter="{x:Static prop:Resources.ToolModeTarget}"
+                                Header="{x:Static prop:Resources.LabelPaste}"/>
+                            <MenuItem
                                 Command="{Binding DataContext.DeletePointCommand}"
                                 CommandParameter="{Binding Path=SelectedItems}"
                                 Header="{x:Static prop:Resources.MenuLabelDelete}" />
                             <MenuItem
                                 Command="{Binding DataContext.DeleteAllPointsCommand}"
                                 CommandParameter="{x:Static prop:Resources.ToolModeTarget}"
-                                Header="{x:Static prop:Resources.MenuLabelDeleteAll}" />
+                                Header="{x:Static prop:Resources.MenuLabelDeleteAll}" />                            
                         </ContextMenu>
                     </ListBox.ContextMenu>
                     <ListBox.InputBindings>
@@ -243,7 +259,7 @@
                             Command="{Binding DeletePointCommand}"
                             CommandParameter="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListBox}}, Path=SelectedItems}" />
                     </ListBox.InputBindings>
-                </ListBox>
+                </ListBox>              
                 <GroupBox
                     Grid.Row="8"
                     Grid.ColumnSpan="4"
@@ -277,7 +293,7 @@
                     Grid.Row="14"
                     Grid.ColumnSpan="3"
                     HorizontalAlignment="Right"
-                    Orientation="Horizontal">
+                    Orientation="Horizontal">                     
                     <Button
                         Grid.Row="14"
                         Grid.Column="0"

--- a/source/addins/VisibilityLibrary/Views/RLOSView.xaml
+++ b/source/addins/VisibilityLibrary/Views/RLOSView.xaml
@@ -147,6 +147,14 @@
                     <ListBox.ContextMenu>
                         <ContextMenu DataContext="{Binding Path=PlacementTarget, RelativeSource={RelativeSource Self}}">
                             <MenuItem
+                                Command="{Binding DataContext.ImportCSVFileCommand}"
+                                CommandParameter="{x:Static prop:Resources.ToolModeObserver}"
+                                Header="{x:Static prop:Resources.LabelImport}"/>
+                            <MenuItem
+                                Command="{Binding DataContext.PasteCoordinatesCommand}"
+                                CommandParameter="{x:Static prop:Resources.ToolModeObserver}"
+                                  Header="{x:Static prop:Resources.LabelPaste}"/>
+                            <MenuItem
                                 Command="{Binding DataContext.DeletePointCommand}"
                                 CommandParameter="{Binding Path=SelectedItems}"
                                 Header="{x:Static prop:Resources.MenuLabelDelete}" />
@@ -341,13 +349,14 @@
                             Grid.Row="5"
                             Grid.ColumnSpan="4"
                             Header="{x:Static prop:Resources.LabelDistance}">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <TextBox
+                            <StackPanel>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBox
                                     x:Name="tbMinDistance"
                                     Grid.Column="0"
                                     Margin="3,3,0,0"
@@ -355,17 +364,17 @@
                                     Style="{StaticResource textboxStyle}"
                                     Text="{Binding MinDistance, UpdateSourceTrigger=PropertyChanged, ValidatesOnExceptions=True}"
                                     Validation.ErrorTemplate="{StaticResource errorTemplate}">
-                                    <TextBox.InputBindings>
-                                        <KeyBinding Key="Enter" Command="{Binding EnterKeyCommand}" />
-                                    </TextBox.InputBindings>
-                                </TextBox>
-                                <TextBlock
+                                        <TextBox.InputBindings>
+                                            <KeyBinding Key="Enter" Command="{Binding EnterKeyCommand}" />
+                                        </TextBox.InputBindings>
+                                    </TextBox>
+                                    <TextBlock
                                     Grid.Column="1"
                                     Margin="3,3,0,0"
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
                                     Text="{x:Static prop:Resources.LabelTo}" />
-                                <TextBox
+                                    <TextBox
                                     x:Name="tbMaxDistance"
                                     Grid.Column="2"
                                     Margin="3,3,0,0"
@@ -373,11 +382,20 @@
                                     Style="{StaticResource textboxStyle}"
                                     Text="{Binding MaxDistance, UpdateSourceTrigger=PropertyChanged, ValidatesOnExceptions=True}"
                                     Validation.ErrorTemplate="{StaticResource errorTemplate}">
-                                    <TextBox.InputBindings>
-                                        <KeyBinding Key="Enter" Command="{Binding EnterKeyCommand}" />
-                                    </TextBox.InputBindings>
-                                </TextBox>
-                            </Grid>
+                                        <TextBox.InputBindings>
+                                            <KeyBinding Key="Enter" Command="{Binding EnterKeyCommand}" />
+                                        </TextBox.InputBindings>
+                                    </TextBox>
+                                </Grid>
+                                <ComboBox
+                                    x:Name="cmbDistanceUnitType"
+                                    Width="Auto"
+                                    Height="Auto"
+                                    Margin="3,3,0,0"
+                                    ItemsSource="{Binding Source={StaticResource lineDistanceData}}"
+                                    SelectedItem="{Binding Path=DistanceUnitType, Mode=TwoWay}">
+                                </ComboBox>
+                            </StackPanel>
                         </GroupBox>
 
                         <GroupBox


### PR DESCRIPTION
This build addresses the GitHub tickets mentioned below:
- #281 - Store LLOS and RLOS results in a organized fashion
- #279 - Use a spreadsheet of values as inputs
- #242 - RLOS - Cutting off viewsheds when a user brings in a non projected data layer
- #123 - RLOS: Distance parameter does not have a dedicated units control (ArcGIS Pro)
- #122 - RLOS: Distance parameter does not have a dedicated units control (ArcMap)
- #120 - LLOS: add progress bar similar to RLOS (ArcGIS Pro)
