### PR TITLE
Delivery of Visibility Addin DotNet – Sprint 1 - 3

### DIFF
--- a/source/addins/ArcMapAddinVisibility/ArcMapAddinVisibility.csproj
+++ b/source/addins/ArcMapAddinVisibility/ArcMapAddinVisibility.csproj
@@ -146,6 +146,7 @@
       <DependentUpon>Config.esriaddinx</DependentUpon>
     </Compile>
     <Compile Include="Models\AddInPoint.cs" />
+    <Compile Include="Models\AddInPointsX.cs" />
     <Compile Include="Models\AMGraphic.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/source/addins/ArcMapAddinVisibility/ArcMapAddinVisibility.csproj
+++ b/source/addins/ArcMapAddinVisibility/ArcMapAddinVisibility.csproj
@@ -146,7 +146,9 @@
       <DependentUpon>Config.esriaddinx</DependentUpon>
     </Compile>
     <Compile Include="Models\AddInPoint.cs" />
-    <Compile Include="Models\AddInPointsX.cs" />
+    <Compile Include="Models\AddInPointObject.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Models\AMGraphic.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/source/addins/ArcMapAddinVisibility/Models/AddInPointObject.cs
+++ b/source/addins/ArcMapAddinVisibility/Models/AddInPointObject.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ArcMapAddinVisibility.Models
+{
+    public class AddInPointObject
+    {
+        private int _id;
+
+        public int ID
+        {
+            get { return _id; }
+            set { _id = value; }
+        }
+        private AddInPoint _addInPoint;
+
+        public AddInPoint AddInPoint
+        {
+            get { return _addInPoint; }
+            set { _addInPoint = value; }
+        }
+        
+    }
+}

--- a/source/addins/ArcMapAddinVisibility/ViewModels/LOSBaseViewModel.cs
+++ b/source/addins/ArcMapAddinVisibility/ViewModels/LOSBaseViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Esri 
+﻿// Copyright 2016 Esri
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,21 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Collections.ObjectModel;
-using System.Collections;
-using ESRI.ArcGIS.Carto;
-using ESRI.ArcGIS.Geodatabase;
+using ArcMapAddinVisibility.Models;
+using CoordinateConversionLibrary.Models;
 using ESRI.ArcGIS.Analyst3D;
-using ESRI.ArcGIS.Geometry;
+using ESRI.ArcGIS.Carto;
 using ESRI.ArcGIS.Display;
+using ESRI.ArcGIS.Geodatabase;
+using ESRI.ArcGIS.Geometry;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Threading;
 using VisibilityLibrary;
 using VisibilityLibrary.Helpers;
-using VisibilityLibrary.Views;
 using VisibilityLibrary.ViewModels;
-using ArcMapAddinVisibility.Models;
+using VisibilityLibrary.Views;
 
 namespace ArcMapAddinVisibility.ViewModels
 {
@@ -37,19 +43,36 @@ namespace ArcMapAddinVisibility.ViewModels
             ObserverOffset = 2.0;
             TargetOffset = 0.0;
             OffsetUnitType = DistanceTypes.Meters;
+            DistanceUnitType = DistanceTypes.Meters;
             AngularUnitType = AngularTypes.DEGREES;
 
             ObserverAddInPoints = new ObservableCollection<AddInPoint>();
+            TargetAddInPoints = new ObservableCollection<AddInPoint>();
+            LLOS_ObserversInExtent = new ObservableCollection<AddInPointObject>();
+            LLOS_ObserversOutOfExtent = new ObservableCollection<AddInPointObject>();
+            LLOS_TargetsInExtent = new ObservableCollection<AddInPointObject>();
+            LLOS_TargetsOutOfExtent = new ObservableCollection<AddInPointObject>();
+            RLOS_ObserversInExtent = new ObservableCollection<AddInPointObject>();
+            RLOS_ObserversOutOfExtent = new ObservableCollection<AddInPointObject>();
+            EnterManullyOption = VisibilityLibrary.Properties.Resources.EnterManuallyOption;
 
             toolMode = MapPointToolMode.Unknown;
             SurfaceLayerNames = new ObservableCollection<string>();
+            LLOS_ObserverLyrNames = new ObservableCollection<string>();
+            LLOS_TargetLyrNames = new ObservableCollection<string>();
+            RLOS_ObserverLyrNames = new ObservableCollection<string>();
             SelectedSurfaceName = string.Empty;
+            SelectedLLOS_ObserverLyrName = string.Empty;
+            SelectedLLOS_TargetLyrName = string.Empty;
+            SelectedRLOS_ObserverLyrName = string.Empty;
 
             Mediator.Register(Constants.MAP_TOC_UPDATED, OnMapTocUpdated);
             Mediator.Register(Constants.DISPLAY_COORDINATE_TYPE_CHANGED, OnDisplayCoordinateTypeChanged);
 
             DeletePointCommand = new RelayCommand(OnDeletePointCommand);
             DeleteAllPointsCommand = new RelayCommand(OnDeleteAllPointsCommand);
+            PasteCoordinatesCommand = new RelayCommand(OnPasteCommand);
+            ImportCSVFileCommand = new RelayCommand(OnImportCSVFileCommand);
             EditPropertiesDialogCommand = new RelayCommand(OnEditPropertiesDialogCommand);
         }
 
@@ -101,6 +124,7 @@ namespace ArcMapAddinVisibility.ViewModels
                     throw new ArgumentException(VisibilityLibrary.Properties.Resources.AEInvalidInput);
             }
         }
+
         private double? targetOffset;
         public double? TargetOffset
         {
@@ -142,12 +166,99 @@ namespace ArcMapAddinVisibility.ViewModels
             }
         }
 
+        private string _selectedLLOS_TargetLyrName;
+        public string SelectedLLOS_TargetLyrName
+        {
+            get
+            {
+                return _selectedLLOS_TargetLyrName;
+            }
+            set
+            {
+                _selectedLLOS_TargetLyrName = value;
+                ValidateLLOS_LayerSelection();
+                RaisePropertyChanged(() => SelectedLLOS_TargetLyrName);
+            }
+        }
+
+        private string _selectedLLOS_ObserverLyrName;
+        public string SelectedLLOS_ObserverLyrName
+        {
+            get
+            {
+                return _selectedLLOS_ObserverLyrName;
+            }
+            set
+            {
+                _selectedLLOS_ObserverLyrName = value;
+                ValidateLLOS_LayerSelection();
+                RaisePropertyChanged(() => SelectedLLOS_ObserverLyrName);
+            }
+        }
+
+        private string _selectedRLOS_ObserverLyrName;
+        public string SelectedRLOS_ObserverLyrName
+        {
+            get
+            {
+                return _selectedRLOS_ObserverLyrName;
+            }
+            set
+            {
+                _selectedRLOS_ObserverLyrName = value;
+                ValidateRLOS_LayerSelection();
+                RaisePropertyChanged(() => SelectedRLOS_ObserverLyrName);
+            }
+        }
+
+        public ObservableCollection<string> LLOS_ObserverLyrNames { get; set; }
+        public ObservableCollection<string> LLOS_TargetLyrNames { get; set; }
+        public ObservableCollection<string> RLOS_ObserverLyrNames { get; set; }
+        
+        private bool _isLLOSValidSelection { get; set; }
+        public bool IsLLOSValidSelection
+        {
+            get
+            {
+                return _isLLOSValidSelection;
+            }
+            set
+            {
+                _isLLOSValidSelection = value;
+                RaisePropertyChanged(() => IsLLOSValidSelection);
+            }
+        }
+        
+        private bool _isRLOSValidSelection { get; set; }
+        public bool IsRLOSValidSelection
+        {
+            get
+            {
+                return _isRLOSValidSelection;
+            }
+            set
+            {
+                _isRLOSValidSelection = value;
+                RaisePropertyChanged(() => IsRLOSValidSelection);
+            }
+        }
+        
+        public string EnterManullyOption { get; set; }
+        public ObservableCollection<AddInPointObject> LLOS_ObserversInExtent { get; set; }
+        public ObservableCollection<AddInPointObject> LLOS_ObserversOutOfExtent { get; set; }
+        public ObservableCollection<AddInPointObject> LLOS_TargetsInExtent { get; set; }
+        public ObservableCollection<AddInPointObject> LLOS_TargetsOutOfExtent { get; set; }
+        public ObservableCollection<AddInPointObject> RLOS_ObserversInExtent { get; set; }
+        public ObservableCollection<AddInPointObject> RLOS_ObserversOutOfExtent { get; set; }
+
         public ObservableCollection<AddInPoint> ObserverAddInPoints { get; set; }
+        public ObservableCollection<AddInPoint> TargetAddInPoints { get; set; }
         public ObservableCollection<string> SurfaceLayerNames { get; set; }
         public string SelectedSurfaceName { get; set; }
         public DistanceTypes OffsetUnitType { get; set; }
+        public DistanceTypes DistanceUnitType { get; set; }
         public AngularTypes AngularUnitType { get; set; }
-        
+
         #endregion
 
         #region Commands
@@ -155,6 +266,8 @@ namespace ArcMapAddinVisibility.ViewModels
         public RelayCommand DeletePointCommand { get; set; }
         public RelayCommand DeleteAllPointsCommand { get; set; }
         public RelayCommand EditPropertiesDialogCommand { get; set; }
+        public RelayCommand PasteCoordinatesCommand { get; set; }
+        public RelayCommand ImportCSVFileCommand { get; set; }
 
         /// <summary>
         /// Command method to delete points
@@ -189,6 +302,7 @@ namespace ArcMapAddinVisibility.ViewModels
 
             dlg.ShowDialog();
         }
+
         private void DeletePoints(List<AddInPoint> observers)
         {
             if (observers == null || !observers.Any())
@@ -201,6 +315,146 @@ namespace ArcMapAddinVisibility.ViewModels
             foreach (var point in observers)
             {
                 ObserverAddInPoints.Remove(point);
+            }
+        }
+
+        /// <summary>
+        /// Command method to import points from csv file.
+        /// </summary>
+        /// <param name="obj"></param>
+        public virtual void OnImportCSVFileCommand(object obj)
+        {
+            var mode = obj.ToString();
+            CoordinateConversionLibraryConfig.AddInConfig.DisplayAmbiguousCoordsDlg = false;
+
+            var fileDialog = new Microsoft.Win32.OpenFileDialog();
+            fileDialog.CheckFileExists = true;
+            fileDialog.CheckPathExists = true;
+            fileDialog.Filter = "csv files|*.csv";
+
+            // attemp to import
+            var fieldVM = new CoordinateConversionLibrary.ViewModels.SelectCoordinateFieldsViewModel();
+            var result = fileDialog.ShowDialog();
+            if (result.HasValue && result.Value == true)
+            {
+                var dlg = new CoordinateConversionLibrary.Views.SelectCoordinateFieldsView();
+                using (Stream s = new FileStream(fileDialog.FileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                {
+                    var headers = CoordinateConversionLibrary.Helpers.ImportCSV.GetHeaders(s);
+                    if (headers != null)
+                    {
+                        foreach (var header in headers)
+                        {
+                            fieldVM.AvailableFields.Add(header);
+                            System.Diagnostics.Debug.WriteLine("header : {0}", header);
+                        }
+                        dlg.DataContext = fieldVM;
+                    }
+                    else
+                    {
+                        System.Windows.Forms.MessageBox.Show(VisibilityLibrary.Properties.Resources.MsgNoDataFound);
+                        return;
+                    }
+                }
+                if (dlg.ShowDialog() == true)
+                {
+                    using (Stream s = new FileStream(fileDialog.FileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                    {
+                        var lists = CoordinateConversionLibrary.Helpers.ImportCSV.Import<CoordinateConversionLibrary.ViewModels.ImportCoordinatesList>(s, fieldVM.SelectedFields.ToArray());
+
+                        foreach (var item in lists)
+                        {
+                            string outFormattedString = string.Empty;
+                            var sb = new StringBuilder();
+                            sb.Append(item.lat.Trim());
+                            if (fieldVM.UseTwoFields)
+                                sb.Append(string.Format(" {0}", item.lon.Trim()));
+
+                            string coordinate = sb.ToString();
+                            CoordinateConversionLibrary.Models.CoordinateType ccType = CoordinateConversionLibrary.Helpers.ConversionUtils.GetCoordinateString(coordinate, out outFormattedString);
+                            if (ccType == CoordinateConversionLibrary.Models.CoordinateType.Unknown)
+                            {
+                                Regex regexMercator = new Regex(@"^(?<latitude>\-?\d+\.?\d*)[+,;:\s]*(?<longitude>\-?\d+\.?\d*)");
+                                var matchMercator = regexMercator.Match(coordinate);
+                                if (matchMercator.Success && matchMercator.Length == coordinate.Length)
+                                {
+                                    ccType = CoordinateType.DD;
+                                }
+                            }
+                            IPoint point = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetPointFromString(outFormattedString) : null;
+                            if (point != null)
+                            {
+                                if (mode == VisibilityLibrary.Properties.Resources.ToolModeObserver)
+                                {
+                                    ToolMode = MapPointToolMode.Observer;
+                                    Point1 = point;
+                                    if ((ArcMap.Document != null) && (ArcMap.Document.FocusMap != null))
+                                        point.Project(ArcMap.Document.FocusMap.SpatialReference);
+                                    OnNewMapPointEvent(Point1);
+                                }
+                                else if (mode == VisibilityLibrary.Properties.Resources.ToolModeTarget)
+                                {
+                                    ToolMode = MapPointToolMode.Target;
+                                    Point2 = point;
+                                    if ((ArcMap.Document != null) && (ArcMap.Document.FocusMap != null))
+                                        point.Project(ArcMap.Document.FocusMap.SpatialReference);
+                                    OnNewMapPointEvent(Point2);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Command method to paste points from clipboard.
+        /// </summary>
+        /// <param name="obj"></param>
+        internal virtual void OnPasteCommand(object obj)
+        {
+            var mode = obj.ToString();
+
+            if (string.IsNullOrWhiteSpace(mode))
+                return;
+
+            var input = Clipboard.GetText().Trim();
+            string[] lines = input.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+            var coordinates = new List<string>();
+            foreach (var item in lines)
+            {
+                string outFormattedString = string.Empty;
+                string coordinate = item.Trim().ToString();
+                CoordinateConversionLibrary.Models.CoordinateType ccType = CoordinateConversionLibrary.Helpers.ConversionUtils.GetCoordinateString(coordinate, out outFormattedString);
+                if (ccType == CoordinateConversionLibrary.Models.CoordinateType.Unknown)
+                {
+                    Regex regexMercator = new Regex(@"^(?<latitude>\-?\d+\.?\d*)[+,;:\s]*(?<longitude>\-?\d+\.?\d*)");
+                    var matchMercator = regexMercator.Match(coordinate);
+                    if (matchMercator.Success && matchMercator.Length == coordinate.Length)
+                    {
+                        ccType = CoordinateType.DD;
+                    }
+                }
+                IPoint point = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetPointFromString(outFormattedString) : null;
+                if (point != null)
+                {
+                    if (mode == VisibilityLibrary.Properties.Resources.ToolModeObserver)
+                    {
+                        ToolMode = MapPointToolMode.Observer;
+                        Point1 = point;
+                        if ((ArcMap.Document != null) && (ArcMap.Document.FocusMap != null))
+                            point.Project(ArcMap.Document.FocusMap.SpatialReference);
+                        OnNewMapPointEvent(Point1);
+                    }
+                    else if (mode == VisibilityLibrary.Properties.Resources.ToolModeTarget)
+                    {
+                        ToolMode = MapPointToolMode.Target;
+                        Point2 = point;
+                        if ((ArcMap.Document != null) && (ArcMap.Document.FocusMap != null))
+                            point.Project(ArcMap.Document.FocusMap.SpatialReference);
+                        OnNewMapPointEvent(Point2);
+                    }
+                }
             }
         }
 
@@ -277,13 +531,14 @@ namespace ArcMapAddinVisibility.ViewModels
             {
                 // in tool mode "Observer" we add observer points
                 // otherwise ignore
-                
+
                 var color = new RgbColorClass() { Blue = 255 } as IColor;
                 var guid = AddGraphicToMap(point, color, true);
                 var addInPoint = new AddInPoint() { Point = point, GUID = guid };
                 ObserverAddInPoints.Insert(0, addInPoint);
             }
         }
+
         internal override void OnMouseMoveEvent(object obj)
         {
             if (!IsActiveTab)
@@ -294,17 +549,18 @@ namespace ArcMapAddinVisibility.ViewModels
             if (point == null)
                 return;
 
-            if(ToolMode == MapPointToolMode.Observer)
+            if (ToolMode == MapPointToolMode.Observer)
             {
                 Point1Formatted = string.Empty;
                 Point1 = point;
             }
-            else if(ToolMode == MapPointToolMode.Target)
+            else if (ToolMode == MapPointToolMode.Target)
             {
                 Point2Formatted = string.Empty;
                 Point2 = point;
             }
         }
+
         /// <summary>
         /// Handler for "Enter" key press
         /// If pressed when input textbox for observer or target is focused
@@ -316,7 +572,7 @@ namespace ArcMapAddinVisibility.ViewModels
         {
             var keyCommandMode = obj as string;
 
-            if(keyCommandMode == VisibilityLibrary.Properties.Resources.ToolModeObserver)
+            if (keyCommandMode == VisibilityLibrary.Properties.Resources.ToolModeObserver)
             {
                 ToolMode = MapPointToolMode.Observer;
                 OnNewMapPointEvent(Point1);
@@ -332,6 +588,7 @@ namespace ArcMapAddinVisibility.ViewModels
                 base.OnEnterKeyCommand(obj);
             }
         }
+
         /// <summary>
         /// Method to check to see point is withing the currently selected surface
         /// returns true if there is no surface selected or point is contained by layer AOI
@@ -452,7 +709,7 @@ namespace ArcMapAddinVisibility.ViewModels
                 var mosaicLayer = layer as IMosaicLayer;
                 var rasterLayer = layer as IRasterLayer;
 
-                if ((mosaicLayer != null) && (mosaicLayer.PreviewLayer != null) && 
+                if ((mosaicLayer != null) && (mosaicLayer.PreviewLayer != null) &&
                     (mosaicLayer.PreviewLayer.Raster != null))
                 {
                     rasterSurface.PutRaster(mosaicLayer.PreviewLayer.Raster, 0);
@@ -520,7 +777,7 @@ namespace ArcMapAddinVisibility.ViewModels
 
             var layer = layers.Next();
 
-            while(layer != null)
+            while (layer != null)
             {
                 try
                 {
@@ -600,7 +857,7 @@ namespace ArcMapAddinVisibility.ViewModels
         }
 
         /// <summary>
-        /// Method used to reset the currently selected surfacename 
+        /// Method used to reset the currently selected surfacename
         /// Use when toc items or map changes, on tab selection changed, etc
         /// </summary>
         /// <param name="map">IMap</param>
@@ -621,8 +878,64 @@ namespace ArcMapAddinVisibility.ViewModels
             else
                 SelectedSurfaceName = string.Empty;
 
+            ResetLayerNames(map);
+
             RaisePropertyChanged(() => SelectedSurfaceName);
+            RaisePropertyChanged(() => SelectedLLOS_ObserverLyrName);
+            RaisePropertyChanged(() => SelectedLLOS_TargetLyrName);
+            RaisePropertyChanged(() => SelectedRLOS_ObserverLyrName);
         }
+
+        private void ResetLayerNames(IMap map)
+        {
+            var layerNames = new ObservableCollection<string>();
+            Dispatcher.CurrentDispatcher.Invoke(() =>
+                {
+                    layerNames = GetLayerNames(map);
+                });
+
+            var tempSelectedLLOS_Observer = SelectedLLOS_ObserverLyrName;
+            var tempSelectedLLOS_Target = SelectedLLOS_TargetLyrName;
+            var tempSelectedRLOS_Observer = SelectedRLOS_ObserverLyrName;
+
+
+            Dispatcher.CurrentDispatcher.Invoke(() =>
+            {
+                ResetLayerCollectionNames(layerNames);
+            });
+            Dispatcher.CurrentDispatcher.Invoke(() =>
+            {
+                ResetSelectedLyrName(tempSelectedLLOS_Observer, tempSelectedLLOS_Target, tempSelectedRLOS_Observer);
+            });
+
+        }
+
+        private void ResetSelectedLyrName(string tempSelectedLLOS_Observer, string tempSelectedLLOS_Target, string tempSelectedRLOS_Observer)
+        {
+            if (SurfaceLayerNames.Contains(tempSelectedLLOS_Observer))
+                SelectedLLOS_ObserverLyrName = tempSelectedLLOS_Observer;
+            else if (SurfaceLayerNames.Any())
+                SelectedLLOS_ObserverLyrName = LLOS_ObserverLyrNames[0];
+            else
+                SelectedLLOS_ObserverLyrName = string.Empty;
+
+
+            if (SurfaceLayerNames.Contains(tempSelectedLLOS_Target))
+                SelectedLLOS_TargetLyrName = tempSelectedLLOS_Target;
+            else if (SurfaceLayerNames.Any())
+                SelectedLLOS_TargetLyrName = LLOS_TargetLyrNames[0];
+            else
+                SelectedLLOS_TargetLyrName = string.Empty;
+
+            if (SurfaceLayerNames.Contains(tempSelectedRLOS_Observer))
+                SelectedRLOS_ObserverLyrName = tempSelectedRLOS_Observer;
+            else if (SurfaceLayerNames.Any())
+                SelectedRLOS_ObserverLyrName = RLOS_ObserverLyrNames[0];
+            else
+                SelectedRLOS_ObserverLyrName = string.Empty;
+        }
+
+
 
         /// <summary>
         /// Method to handle the display coordinate type change
@@ -636,6 +949,139 @@ namespace ArcMapAddinVisibility.ViewModels
             foreach (var item in list)
                 ObserverAddInPoints.Add(item);
             RaisePropertyChanged(() => HasMapGraphics);
+        }
+
+        private void ResetLayerCollectionNames(ObservableCollection<string> layerNames)
+        {
+            LLOS_ObserverLyrNames.Clear();
+            LLOS_TargetLyrNames.Clear();
+            RLOS_ObserverLyrNames.Clear();
+
+            if (!LLOS_ObserverLyrNames.Contains(EnterManullyOption))
+            {
+                LLOS_ObserverLyrNames.Add(EnterManullyOption);
+                LLOS_TargetLyrNames.Add(EnterManullyOption);
+                RLOS_ObserverLyrNames.Add(EnterManullyOption);
+            }
+
+            foreach (var layerName in layerNames)
+            {
+                if (!LLOS_ObserverLyrNames.Contains(layerName))
+                {
+                    LLOS_ObserverLyrNames.Add(layerName);
+                    LLOS_TargetLyrNames.Add(layerName);
+                    RLOS_ObserverLyrNames.Add(layerName);
+                }
+            }
+        }
+
+        private ObservableCollection<string> GetLayerNames(IMap map)
+        {
+            var layerNames = new ObservableCollection<string>();
+
+            if (map == null)
+                return layerNames;
+
+            var layers = map.get_Layers();
+
+            if (layers == null)
+                return layerNames;
+            var layer = layers.Next();
+            while (layer != null)
+            {
+                var lyr = layer as FeatureClass;
+                if (lyr != null && lyr.Type == esriDatasetType.esriDTFeatureClass)
+                {
+                    IFeatureLayer FLayer = (IFeatureLayer)lyr;
+                    var geomertyType = FLayer.FeatureClass.ShapeType;
+                    if (geomertyType == esriGeometryType.esriGeometryPoint)
+                        layerNames.Add(layer.Name);
+                }
+                layer = layers.Next();
+            }
+            return layerNames;
+        }
+
+        internal void ValidateLLOS_LayerSelection()
+        {
+            if (SelectedLLOS_ObserverLyrName == EnterManullyOption)
+            {
+                LLOS_ObserversInExtent.Clear();
+                LLOS_ObserversOutOfExtent.Clear();
+            }
+            if (SelectedLLOS_TargetLyrName == EnterManullyOption)
+            {
+                LLOS_TargetsInExtent.Clear();
+                LLOS_TargetsOutOfExtent.Clear();
+            }
+
+            IsLLOSValidSelection = (
+                ((SelectedLLOS_ObserverLyrName == EnterManullyOption || string.IsNullOrWhiteSpace(SelectedLLOS_ObserverLyrName))
+                && LLOS_ObserversInExtent.Count == 0 && LLOS_ObserversOutOfExtent.Count == 0 && ObserverAddInPoints.Count == 0)
+                ||
+                ((SelectedLLOS_TargetLyrName == EnterManullyOption || string.IsNullOrWhiteSpace(SelectedLLOS_TargetLyrName))
+                && LLOS_TargetsInExtent.Count == 0 && LLOS_TargetsOutOfExtent.Count == 0 && TargetAddInPoints.Count == 0)
+                ) ? false : true;
+        }
+
+        internal void ValidateRLOS_LayerSelection()
+        {
+            IsRLOSValidSelection =
+                ((SelectedRLOS_ObserverLyrName == EnterManullyOption || string.IsNullOrWhiteSpace(SelectedRLOS_ObserverLyrName))
+                && RLOS_ObserversInExtent.Count == 0 && RLOS_ObserversOutOfExtent.Count == 0) ? false : true;
+        }
+
+        internal void ReadSelectedLyrPoints(ObservableCollection<AddInPointObject> inExtentPoints, ObservableCollection<AddInPointObject> outOfExtentPoints, string selectedLyrName, IColor color)
+        {
+            var map = ArcMap.Document.FocusMap;
+            if (map == null)
+                return;
+            var layers = map.get_Layers();
+            if (layers == null)
+                return;
+            var layer = layers.Next();
+            while (layer != null)
+            {
+                if (layer.Name == selectedLyrName)
+                {
+                    IFeature feature = null;
+                    IFeatureLayer FLayer = (IFeatureLayer)layer;
+                    var cursor = FLayer.FeatureClass.Search(null, false);
+                    var surface = GetSurfaceFromMapByName(ArcMap.Document.FocusMap, SelectedSurfaceName);
+                    double finalObserverOffset = GetOffsetInZUnits(ObserverOffset.Value, surface.ZFactor, OffsetUnitType);
+                    while ((feature = cursor.NextFeature()) != null)
+                    {
+                        var value = feature.get_Value(FLayer.FeatureClass.FindField("Shape"));
+                        var point = (IPoint)value;
+                        var guid = AddGraphicToMap(point, color, true, esriSimpleMarkerStyle.esriSMSSquare);
+                        var objectId = FLayer.FeatureClass.FindField("ObjectId");
+                        var FID = FLayer.FeatureClass.FindField("FID");
+                        var idIndex = objectId != -1 ? objectId : FID;
+                        var id = Convert.ToInt32(feature.get_Value(idIndex));
+                        var z1 = surface.GetElevation(point) + finalObserverOffset;
+                        var addInPoint = new AddInPoint() { Point = point, GUID = guid };
+                        if (double.IsNaN(z1))
+                            outOfExtentPoints.Add(new AddInPointObject() { AddInPoint = addInPoint, ID = id });
+                        else
+                            inExtentPoints.Add(new AddInPointObject() { AddInPoint = addInPoint, ID = id });
+                    }
+                }
+                layer = layers.Next();
+            }
+        }
+
+        internal void ClearLLOSCollections()
+        {
+            LLOS_TargetsInExtent.Clear();
+            LLOS_TargetsOutOfExtent.Clear();
+            LLOS_ObserversInExtent.Clear();
+            LLOS_ObserversOutOfExtent.Clear();
+        }
+
+        internal void ClearRLOSCollections()
+        {
+            RLOS_ObserversInExtent.Clear();
+            RLOS_ObserversOutOfExtent.Clear();
         }
     }
 }

--- a/source/addins/ArcMapAddinVisibility/ViewModels/TabBaseViewModel.cs
+++ b/source/addins/ArcMapAddinVisibility/ViewModels/TabBaseViewModel.cs
@@ -68,7 +68,7 @@ namespace ArcMapAddinVisibility.ViewModels
         {
             string currentActiveToolName = obj as string;
 
-            if ((currentActiveToolName == ThisAddIn.IDs.MapPointTool))   
+            if ((currentActiveToolName == ThisAddIn.IDs.MapPointTool))
                 return;
 
             lastActiveToolName = currentActiveToolName;
@@ -411,7 +411,7 @@ namespace ArcMapAddinVisibility.ViewModels
                 }
             }
             elementList.Clear();
-            
+
             RaisePropertyChanged(() => HasMapGraphics);
         }
 
@@ -502,11 +502,11 @@ namespace ArcMapAddinVisibility.ViewModels
                 return;
             }
 
-            if ((ArcMap.Application.CurrentTool != null) && 
+            if ((ArcMap.Application.CurrentTool != null) &&
                 (ArcMap.Application.CurrentTool.Name.Equals(toolName)))
-                    // Tricky: Check if tool already active - because setting CurrentTool again will 
-                    //         cause Activate/Deactive to be called by ArcGIS framework
-                    return;
+                // Tricky: Check if tool already active - because setting CurrentTool again will 
+                //         cause Activate/Deactive to be called by ArcGIS framework
+                return;
 
             ESRI.ArcGIS.Framework.ICommandBars commandBars = ArcMap.Application.Document.CommandBars;
             ESRI.ArcGIS.esriSystem.UID commandID = new ESRI.ArcGIS.esriSystem.UIDClass();
@@ -530,36 +530,36 @@ namespace ArcMapAddinVisibility.ViewModels
 
             try
             {
-            var cn = point as IConversionNotation;
-            if (cn != null)
-            {
-                switch (VisibilityConfig.AddInConfig.DisplayCoordinateType)
+                var cn = point as IConversionNotation;
+                if (cn != null)
                 {
-                    case CoordinateTypes.DD:
-                        result = cn.GetDDFromCoords(6);
-                        break;
-                    case CoordinateTypes.DDM:
-                        result = cn.GetDDMFromCoords(4);
-                        break;
-                    case CoordinateTypes.DMS:
-                        result = cn.GetDMSFromCoords(2);
-                        break;
-                    //case CoordinateTypes.GARS:
-                    //    result = cn.GetGARSFromCoords();
-                    //    break;
-                    case CoordinateTypes.MGRS:
-                        result = cn.CreateMGRS(5, true, esriMGRSModeEnum.esriMGRSMode_Automatic);
-                        break;
-                    case CoordinateTypes.USNG:
-                        result = cn.GetUSNGFromCoords(5, true, true);
-                        break;
-                    case CoordinateTypes.UTM:
-                        result = cn.GetUTMFromCoords(esriUTMConversionOptionsEnum.esriUTMAddSpaces | esriUTMConversionOptionsEnum.esriUTMUseNS);
-                        break;
-                    default:
-                        break;
+                    switch (VisibilityConfig.AddInConfig.DisplayCoordinateType)
+                    {
+                        case CoordinateTypes.DD:
+                            result = cn.GetDDFromCoords(6);
+                            break;
+                        case CoordinateTypes.DDM:
+                            result = cn.GetDDMFromCoords(4);
+                            break;
+                        case CoordinateTypes.DMS:
+                            result = cn.GetDMSFromCoords(2);
+                            break;
+                        //case CoordinateTypes.GARS:
+                        //    result = cn.GetGARSFromCoords();
+                        //    break;
+                        case CoordinateTypes.MGRS:
+                            result = cn.CreateMGRS(5, true, esriMGRSModeEnum.esriMGRSMode_Automatic);
+                            break;
+                        case CoordinateTypes.USNG:
+                            result = cn.GetUSNGFromCoords(5, true, true);
+                            break;
+                        case CoordinateTypes.UTM:
+                            result = cn.GetUTMFromCoords(esriUTMConversionOptionsEnum.esriUTMAddSpaces | esriUTMConversionOptionsEnum.esriUTMUseNS);
+                            break;
+                        default:
+                            break;
+                    }
                 }
-            }
             }
             catch (Exception ex)
             {
@@ -653,9 +653,12 @@ namespace ArcMapAddinVisibility.ViewModels
         /// Adds a graphic element to the map graphics container
         /// </summary>
         /// <param name="geom">IGeometry</param>
-        internal string AddGraphicToMap(IGeometry geom, IColor color, bool IsTempGraphic = false, 
-            esriSimpleMarkerStyle markerStyle = esriSimpleMarkerStyle.esriSMSCircle, int size = 5)
+        internal string AddGraphicToMap(IGeometry geom, IColor color, bool IsTempGraphic = false,
+            esriSimpleMarkerStyle markerStyle = esriSimpleMarkerStyle.esriSMSCircle, int size = 5, IColor borderColor = null)
         {
+            if (borderColor == null)
+                borderColor = color;
+
             if (geom == null || ArcMap.Document == null || ArcMap.Document.FocusMap == null)
                 return string.Empty;
 
@@ -669,7 +672,7 @@ namespace ArcMapAddinVisibility.ViewModels
                 var simpleMarkerSymbol = (ISimpleMarkerSymbol)new SimpleMarkerSymbol();
                 simpleMarkerSymbol.Color = color;
                 simpleMarkerSymbol.Outline = true;
-                simpleMarkerSymbol.OutlineColor = color;
+                simpleMarkerSymbol.OutlineColor = borderColor;
                 simpleMarkerSymbol.Size = size;
                 simpleMarkerSymbol.Style = markerStyle;
 
@@ -695,7 +698,7 @@ namespace ArcMapAddinVisibility.ViewModels
                 IPolygonElement pe = (IPolygonElement)new PolygonElementClass();
                 element = pe as IElement;
                 IFillShapeElement fe = (IFillShapeElement)pe;
-                
+
                 var fillSymbol = new SimpleFillSymbolClass();
                 RgbColor selectedColor = new RgbColorClass();
                 selectedColor.Red = 0;
@@ -703,8 +706,8 @@ namespace ArcMapAddinVisibility.ViewModels
                 selectedColor.Blue = 0;
 
                 selectedColor.Transparency = (byte)0;
-                fillSymbol.Color = selectedColor;  
-                
+                fillSymbol.Color = selectedColor;
+
                 fe.Symbol = fillSymbol;
             }
 
@@ -720,7 +723,7 @@ namespace ArcMapAddinVisibility.ViewModels
             var eprop = (IElementProperties)element;
             eprop.Name = Guid.NewGuid().ToString();
 
-            GraphicsList.Add(new AMGraphic(eprop.Name, geom, IsTempGraphic)); 
+            GraphicsList.Add(new AMGraphic(eprop.Name, geom, IsTempGraphic));
 
             gc.AddElement(element, 0);
 
@@ -732,7 +735,7 @@ namespace ArcMapAddinVisibility.ViewModels
         }
 
         internal DistanceTypes GetDistanceType(int linearUnitFactoryCode)
-        { 
+        {
             DistanceTypes distanceType = DistanceTypes.Meters;
             switch (linearUnitFactoryCode)
             {
@@ -826,7 +829,7 @@ namespace ArcMapAddinVisibility.ViewModels
             var av = (IActiveView)ArcMap.Document.FocusMap;
 
             IEnvelope env = geom.Envelope;
-
+            
             double extentPercent = (env.XMax - env.XMin) > (env.YMax - env.YMin) ? (env.XMax - env.XMin) * .3 : (env.YMax - env.YMin) * .3;
             env.XMax = env.XMax + extentPercent;
             env.XMin = env.XMin - extentPercent;

--- a/source/addins/ProAppVisibilityModule/Models/AddInPointObject.cs
+++ b/source/addins/ProAppVisibilityModule/Models/AddInPointObject.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ProAppVisibilityModule.Models
+{
+    public class AddInPointObject
+    {
+        private int _id;
+        public int ID
+        {
+            get { return _id; }
+            set { _id = value; }
+        }
+        private AddInPoint addInPoint;
+
+        public AddInPoint AddInPoint
+        {
+            get { return addInPoint; }
+            set { addInPoint = value; }
+        }
+        
+    }
+}

--- a/source/addins/ProAppVisibilityModule/ProAppVisibilityModule.csproj
+++ b/source/addins/ProAppVisibilityModule/ProAppVisibilityModule.csproj
@@ -112,7 +112,9 @@
     <Compile Include="Helpers\GeometryHelper.cs" />
     <Compile Include="Helpers\MapPointHelper.cs" />
     <Compile Include="Models\AddInPoint.cs" />
-    <Compile Include="Models\AddInPointX.cs" />
+    <Compile Include="Models\AddInPointObject.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Models\ProGraphic.cs" />
     <Compile Include="ViewModels\ProLLOSViewModel.cs" />
     <Compile Include="ViewModels\ProLOSBaseViewModel.cs" />

--- a/source/addins/ProAppVisibilityModule/ProAppVisibilityModule.csproj
+++ b/source/addins/ProAppVisibilityModule/ProAppVisibilityModule.csproj
@@ -53,6 +53,12 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ESRI.ArcGIS.Display, Version=10.3.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="ESRI.ArcGIS.GraphicsSymbols, Version=10.3.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -106,6 +112,7 @@
     <Compile Include="Helpers\GeometryHelper.cs" />
     <Compile Include="Helpers\MapPointHelper.cs" />
     <Compile Include="Models\AddInPoint.cs" />
+    <Compile Include="Models\AddInPointX.cs" />
     <Compile Include="Models\ProGraphic.cs" />
     <Compile Include="ViewModels\ProLLOSViewModel.cs" />
     <Compile Include="ViewModels\ProLOSBaseViewModel.cs" />
@@ -113,6 +120,10 @@
     <Compile Include="ViewModels\ProTabBaseViewModel.cs" />
     <Compile Include="Views\ProEditPropertiesView.xaml.cs">
       <DependentUpon>ProEditPropertiesView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\ProSelectCoordinateFieldsView.xaml.cs">
+      <DependentUpon>ProSelectCoordinateFieldsView.xaml</DependentUpon>
+      <SubType>Code</SubType>
     </Compile>
     <Compile Include="VisibilityMapTool.cs" />
     <Compile Include="PropertiesButton.cs" />
@@ -127,6 +138,10 @@
     <Page Include="Views\ProEditPropertiesView.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views\ProSelectCoordinateFieldsView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="VisibilityDockpane.xaml">
       <SubType>Designer</SubType>
@@ -180,9 +195,10 @@
     </XmlPeek>
     <Message Importance="High" Text="old build number @(Peeked) new build number $(BUILD_MAJOR).$(BUILD_MINOR).$(BUILD_PATCH).$(BUILD_NUMBER)" />
     <XmlPoke XmlInputPath="Config.daml" Query="//@version[1]" Value="$(BUILD_MAJOR).$(BUILD_MINOR).$(BUILD_PATCH).$(BUILD_NUMBER)" />
-    <XmlPeek XmlInputPath="Config.daml" Query="/x:ArcGIS/x:AddInInfo/x:Date/text()" Namespaces="&lt;Namespace Prefix='x' Uri='http://schemas.esri.com/DADF/Registry' /&gt;"> <Output TaskParameter="Result" ItemName="Peeked_Date" />
+    <XmlPeek XmlInputPath="Config.daml" Query="/x:ArcGIS/x:AddInInfo/x:Date/text()" Namespaces="&lt;Namespace Prefix='x' Uri='http://schemas.esri.com/DADF/Registry' /&gt;">
+      <Output TaskParameter="Result" ItemName="Peeked_Date" />
     </XmlPeek>
     <Message Importance="High" Text="Old build date @(Peeked_Date) New build date $(BUILD_DATE)" />
-    <XmlPoke XmlInputPath="Config.daml" Query="/x:ArcGIS/x:AddInInfo/x:Date" Namespaces="&lt;Namespace Prefix='x' Uri='http://schemas.esri.com/DADF/Registry' /&gt;" Value="$(BUILD_DATE)"/>
+    <XmlPoke XmlInputPath="Config.daml" Query="/x:ArcGIS/x:AddInInfo/x:Date" Namespaces="&lt;Namespace Prefix='x' Uri='http://schemas.esri.com/DADF/Registry' /&gt;" Value="$(BUILD_DATE)" />
   </Target>
 </Project>

--- a/source/addins/ProAppVisibilityModule/ViewModels/ProRLOSViewModel.cs
+++ b/source/addins/ProAppVisibilityModule/ViewModels/ProRLOSViewModel.cs
@@ -28,6 +28,10 @@ using ArcGIS.Desktop.Core.Geoprocessing;
 using ArcGIS.Core.Data;
 using ArcGIS.Desktop.Editing;
 using ArcGIS.Desktop.Framework.Threading.Tasks;
+using System.Text.RegularExpressions;
+using System.Collections.ObjectModel;
+using ProAppVisibilityModule.Models;
+using ArcGIS.Core.CIM;
 
 namespace ProAppVisibilityModule.ViewModels
 {
@@ -35,27 +39,47 @@ namespace ProAppVisibilityModule.ViewModels
     {
         #region Properties
 
-        private int executionCounter = 1;
+        private int executionCounter = 0;
         private string _ObserversLayerName = VisibilityLibrary.Properties.Resources.RLOSObserversLayerName;
         public string ObserversLayerName
         {
-            get 
+            get
             {
-                _ObserversLayerName = string.Format("{0}_{1}", VisibilityLibrary.Properties.Resources.RLOSObserversLayerName, executionCounter);
+                if (executionCounter > 0)
+                {
+                    _ObserversLayerName = string.Format("{0}_{1}", VisibilityLibrary.Properties.Resources.RLOSObserversLayerName, executionCounter);
+                }
                 return _ObserversLayerName;
             }
-            set {}
+            set { }
+        }
+
+        private string _FeatureDatasetName = VisibilityLibrary.Properties.Resources.RLOSFeatureDatasetName;
+        public string FeatureDatasetName
+        {
+            get
+            {
+                if (executionCounter > 0)
+                {
+                    _FeatureDatasetName = string.Format("{0}_{1}", VisibilityLibrary.Properties.Resources.RLOSFeatureDatasetName, executionCounter);
+                }
+                return _FeatureDatasetName;
+            }
+            set { }
         }
 
         private string _RLOSConvertedPolygonsLayerName = VisibilityLibrary.Properties.Resources.RLOSConvertedPolygonsLayerName;
         public string RLOSConvertedPolygonsLayerName
         {
-             get 
+            get
             {
-                _RLOSConvertedPolygonsLayerName = string.Format("{0}_{1}", VisibilityLibrary.Properties.Resources.RLOSConvertedPolygonsLayerName, executionCounter);
+                if (executionCounter > 0)
+                {
+                    _RLOSConvertedPolygonsLayerName = string.Format("{0}_{1}", VisibilityLibrary.Properties.Resources.RLOSConvertedPolygonsLayerName, executionCounter);
+                }
                 return _RLOSConvertedPolygonsLayerName;
             }
-            set {}
+            set { }
         }
 
         private string _RLOSOutputLayerName = VisibilityLibrary.Properties.Resources.RLOSOutputLayerName;
@@ -63,7 +87,10 @@ namespace ProAppVisibilityModule.ViewModels
         {
             get
             {
-                _RLOSOutputLayerName = string.Format("{0}_{1}", VisibilityLibrary.Properties.Resources.RLOSOutputLayerName, executionCounter);
+                if (executionCounter > 0)
+                {
+                    _RLOSOutputLayerName = string.Format("{0}_{1}", VisibilityLibrary.Properties.Resources.RLOSOutputLayerName, executionCounter);
+                }
                 return _RLOSOutputLayerName;
             }
             set { }
@@ -74,19 +101,22 @@ namespace ProAppVisibilityModule.ViewModels
         {
             get
             {
-                _RLOSMaskLayerName = string.Format("{0}_{1}", VisibilityLibrary.Properties.Resources.RLOSMaskLayerName, executionCounter);
+                if (executionCounter > 0)
+                {
+                    _RLOSMaskLayerName = string.Format("{0}_{1}", VisibilityLibrary.Properties.Resources.RLOSMaskLayerName, executionCounter);
+                }
                 return _RLOSMaskLayerName;
             }
             set { }
         }
 
         private double _SurfaceOffset = 0.0;
-        public double SurfaceOffset 
+        public double SurfaceOffset
         {
             get { return _SurfaceOffset; }
             set
             {
-                if(value < 0.0)
+                if (value < 0.0)
                     throw new ArgumentException(VisibilityLibrary.Properties.Resources.AEMustBePositive);
 
                 _SurfaceOffset = value;
@@ -95,15 +125,15 @@ namespace ProAppVisibilityModule.ViewModels
         }
 
         private double _MinDistance = 0.0;
-        public double MinDistance 
+        public double MinDistance
         {
             get { return _MinDistance; }
             set
             {
-                if(value < 0.0)
+                if (value < 0.0)
                     throw new ArgumentException(VisibilityLibrary.Properties.Resources.AEMustBePositive);
 
-                if(value > MaxDistance)
+                if (value > MaxDistance)
                     throw new ArgumentException(VisibilityLibrary.Properties.Resources.AENumMustBeLess);
 
                 _MinDistance = value;
@@ -112,12 +142,12 @@ namespace ProAppVisibilityModule.ViewModels
         }
 
         private double _MaxDistance = 1000.0;
-        public double MaxDistance 
+        public double MaxDistance
         {
             get { return _MaxDistance; }
             set
             {
-                if(value < 0.0)
+                if (value < 0.0)
                     throw new ArgumentException(VisibilityLibrary.Properties.Resources.AEMustBePositive);
 
                 if (value < MinDistance)
@@ -130,7 +160,7 @@ namespace ProAppVisibilityModule.ViewModels
 
         private double _LeftHorizontalFOV = 0.0;
         public double LeftHorizontalFOV
-        { 
+        {
             get { return _LeftHorizontalFOV; }
             set
             {
@@ -144,7 +174,7 @@ namespace ProAppVisibilityModule.ViewModels
             }
         }
         private double _RightHorizontalFOV = 360.0;
-        public double RightHorizontalFOV 
+        public double RightHorizontalFOV
         {
             get { return _RightHorizontalFOV; }
             set
@@ -175,7 +205,7 @@ namespace ProAppVisibilityModule.ViewModels
         }
 
         private double _TopVerticalFOV = 90.0;
-        public double TopVerticalFOV 
+        public double TopVerticalFOV
         {
             get { return _TopVerticalFOV; }
             set
@@ -216,6 +246,7 @@ namespace ProAppVisibilityModule.ViewModels
         private async void OnSubmitCommand(object obj)
         {
             DisplayProgressBar = Visibility.Visible;
+            IsRLOSValidSelection = false;
             await CreateMapElement();
             DisplayProgressBar = Visibility.Hidden;
         }
@@ -252,11 +283,13 @@ namespace ProAppVisibilityModule.ViewModels
         internal override void OnDeletePointCommand(object obj)
         {
             base.OnDeletePointCommand(obj);
+            ValidateRLOS_LayerSelection();
         }
 
         internal override void OnDeleteAllPointsCommand(object obj)
         {
             base.OnDeleteAllPointsCommand(obj);
+            ValidateRLOS_LayerSelection();
         }
 
         public override bool CanCreateElement
@@ -264,7 +297,9 @@ namespace ProAppVisibilityModule.ViewModels
             get
             {
                 return (!string.IsNullOrWhiteSpace(SelectedSurfaceName)
-                    && ObserverAddInPoints.Any());
+                    && (ObserverAddInPoints.Any()
+                    || RLOS_ObserversInExtent.Any()
+                    || RLOS_ObserversOutOfExtent.Any()));
             }
         }
 
@@ -276,6 +311,7 @@ namespace ProAppVisibilityModule.ViewModels
             try
             {
                 IsRunning = true;
+                await ReadSelectedLayers();
 
                 if (!CanCreateElement || MapView.Active == null || MapView.Active.Map == null || string.IsNullOrWhiteSpace(SelectedSurfaceName))
                     return;
@@ -283,7 +319,7 @@ namespace ProAppVisibilityModule.ViewModels
                 bool success = await ExecuteVisibilityRLOS();
 
                 if (!success)
-                    MessageBox.Show("LLOS computations did not complete correctly.\nPlease check your parameters and try again.",
+                    MessageBox.Show("RLOS computations did not complete correctly.\nPlease check your parameters and try again.",
                         VisibilityLibrary.Properties.Resources.CaptionError);
 
                 DeactivateTool(VisibilityMapTool.ToolId);
@@ -299,6 +335,13 @@ namespace ProAppVisibilityModule.ViewModels
             finally
             {
                 IsRunning = false;
+                if (ObserverAddInPoints.Count == 0)
+                    IsRLOSValidSelection = false;
+                else
+                    IsRLOSValidSelection = true;
+
+                ClearRLOSCollections();
+                ValidateRLOS_LayerSelection();
             }
         }
 
@@ -314,12 +357,13 @@ namespace ProAppVisibilityModule.ViewModels
             {
                 // Check surface spatial reference
                 var surfaceSR = await GetSpatialReferenceFromLayer(SelectedSurfaceName);
-                if(surfaceSR == null || !surfaceSR.IsProjected)
+                if (surfaceSR == null || !surfaceSR.IsProjected)
                 {
                     MessageBox.Show(VisibilityLibrary.Properties.Resources.RLOSUserPrompt, VisibilityLibrary.Properties.Resources.RLOSUserPromptCaption);
                     return false;
                 }
 
+                var observerPoints = new ObservableCollection<AddInPoint>(RLOS_ObserversInExtent.Select(x => x.AddInPoint).Union(ObserverAddInPoints));
                 // Warn if Image Service layer
                 Layer surfaceLayer = GetLayerFromMapByName(SelectedSurfaceName);
                 if (surfaceLayer is ImageServiceLayer)
@@ -334,7 +378,36 @@ namespace ProAppVisibilityModule.ViewModels
                     }
                 }
 
-                success = await FeatureClassHelper.CreateLayer(ObserversLayerName, "POINT", true, true);
+                //Validate Dataframe Spatial reference with surface spatial reference
+                if (MapView.Active.Map.SpatialReference.Wkid != surfaceSR.Wkid)
+                {
+                    MessageBox.Show(VisibilityLibrary.Properties.Resources.LOSDataFrameMatch, VisibilityLibrary.Properties.Resources.LOSSpatialReferenceCaption);
+                    return false;
+                }
+
+                await ArcGIS.Desktop.Framework.Threading.Tasks.QueuedTask.Run(() =>
+                {
+                    using (Geodatabase geodatabase = new Geodatabase(new FileGeodatabaseConnectionPath(new Uri(CoreModule.CurrentProject.DefaultGeodatabasePath))))
+                    {
+                        executionCounter = 0;
+                        var enterpriseDefinitionNames = geodatabase.GetDefinitions<FeatureDatasetDefinition>().Where(i => i.GetName().StartsWith(VisibilityLibrary.Properties.Resources.RLOSFeatureDatasetName)).Select(i => i.GetName()).ToList();
+                        foreach (var defName in enterpriseDefinitionNames)
+                        {
+                            int n;
+                            bool isNumeric = int.TryParse(Regex.Match(defName, @"\d+$").Value, out n);
+                            if (isNumeric)
+                                executionCounter = executionCounter < n ? n : executionCounter;
+                        }
+                        executionCounter = enterpriseDefinitionNames.Count > 0 ? executionCounter + 1 : 0;
+                    }
+                });
+
+                //Create Feature dataset
+                success = await FeatureClassHelper.CreateFeatureDataset(FeatureDatasetName);
+                if (!success)
+                    return false;
+
+                success = await FeatureClassHelper.CreateLayer(FeatureDatasetName, ObserversLayerName, "POINT", true, true);
                 if (!success)
                     return false;
 
@@ -342,77 +415,102 @@ namespace ProAppVisibilityModule.ViewModels
 
                 await FeatureClassHelper.AddFieldToLayer(ObserversLayerName, VisibilityLibrary.Properties.Resources.OffsetFieldName, "DOUBLE");
                 await FeatureClassHelper.AddFieldToLayer(ObserversLayerName, VisibilityLibrary.Properties.Resources.OffsetWithZFieldName, "DOUBLE");
+                await FeatureClassHelper.AddFieldToLayer(ObserversLayerName, VisibilityLibrary.Properties.Resources.IsOutOfExtentFieldName, "SHORT");
 
                 // add observer points to feature layer
+                await FeatureClassHelper.CreatingFeatures(ObserversLayerName, observerPoints, GetAsMapZUnits(surfaceSR, ObserverOffset.Value));
 
-                await FeatureClassHelper.CreatingFeatures(ObserversLayerName, ObserverAddInPoints, GetAsMapZUnits(surfaceSR, ObserverOffset.Value));
-
-                // update with surface information
-
-                success = await FeatureClassHelper.AddSurfaceInformation(ObserversLayerName, SelectedSurfaceName, VisibilityLibrary.Properties.Resources.ZFieldName);
-                if (!success)
-                    return false;
-
-                // Visibility
-
-                var observerOffsetInMapZUnits = GetAsMapZUnits(surfaceSR, ObserverOffset.Value);
-                var surfaceOffsetInMapZUnits = GetAsMapZUnits(surfaceSR, SurfaceOffset);
-                var minDistanceInMapUnits = GetAsMapUnits(surfaceSR, MinDistance);
-                var maxDistanceInMapUnits = GetAsMapUnits(surfaceSR, MaxDistance);
-                var horizontalStartAngleInDegrees = GetAngularDistanceFromTo(AngularUnitType, AngularTypes.DEGREES, LeftHorizontalFOV);
-                var horizontalEndAngleInDegrees = GetAngularDistanceFromTo(AngularUnitType, AngularTypes.DEGREES, RightHorizontalFOV);
-                var verticalUpperAngleInDegrees = GetAngularDistanceFromTo(AngularUnitType, AngularTypes.DEGREES, TopVerticalFOV);
-                var verticalLowerAngleInDegrees = GetAngularDistanceFromTo(AngularUnitType, AngularTypes.DEGREES, BottomVerticalFOV);
-
-                await FeatureClassHelper.UpdateShapeWithZ(ObserversLayerName, VisibilityLibrary.Properties.Resources.ZFieldName, observerOffsetInMapZUnits);
-
-                await CreateMask(RLOSMaskLayerName, minDistanceInMapUnits, maxDistanceInMapUnits, horizontalStartAngleInDegrees,
-                    horizontalEndAngleInDegrees, surfaceSR);
-
-                string maxRangeMaskFeatureClassName = CoreModule.CurrentProject.DefaultGeodatabasePath + System.IO.Path.DirectorySeparatorChar + RLOSMaskLayerName;
-                var environments = Geoprocessing.MakeEnvironmentArray(mask: maxRangeMaskFeatureClassName, overwriteoutput: true);
-
-                var rlosOutputLayer = CoreModule.CurrentProject.DefaultGeodatabasePath + System.IO.Path.DirectorySeparatorChar + RLOSOutputLayerName;
-
-                success = await FeatureClassHelper.CreateVisibility(SelectedSurfaceName, ObserversLayerName,
-                    rlosOutputLayer,
-                    observerOffsetInMapZUnits, surfaceOffsetInMapZUnits,
-                    minDistanceInMapUnits, maxDistanceInMapUnits,
-                    horizontalStartAngleInDegrees, horizontalEndAngleInDegrees,
-                    verticalUpperAngleInDegrees, verticalLowerAngleInDegrees,
-                    ShowNonVisibleData,
-                    environments,
-                    false);
-
-                if (!success)
-                    return false;
-
-                var rlosConvertedPolygonsLayer = CoreModule.CurrentProject.DefaultGeodatabasePath + System.IO.Path.DirectorySeparatorChar + RLOSConvertedPolygonsLayerName;
-
-                string rangeFanMaskFeatureClassName = string.Empty;
-                if ((MinDistance > 0) || !((horizontalStartAngleInDegrees == 0.0) && (horizontalEndAngleInDegrees == 360.0)))
+                //execute only if points are available in surface extent
+                if (ObserverAddInPoints.Any() || RLOS_ObserversInExtent.Any())
                 {
-                    string RLOSRangeFanMaskLayerName = "RangeFan_" + RLOSMaskLayerName;
-                    rangeFanMaskFeatureClassName = CoreModule.CurrentProject.DefaultGeodatabasePath + System.IO.Path.DirectorySeparatorChar + RLOSRangeFanMaskLayerName;
+                    // update with surface information
+                    success = await FeatureClassHelper.AddSurfaceInformation(ObserversLayerName, SelectedSurfaceName, VisibilityLibrary.Properties.Resources.ZFieldName);
+                    if (!success)
+                        return false;
 
-                    await CreateMask(RLOSRangeFanMaskLayerName, minDistanceInMapUnits, maxDistanceInMapUnits, horizontalStartAngleInDegrees,
-                        horizontalEndAngleInDegrees, surfaceSR, true);
+                    // Visibility
+
+                    var observerOffsetInMapZUnits = GetAsMapZUnits(surfaceSR, ObserverOffset.Value);
+                    var surfaceOffsetInMapZUnits = GetAsMapZUnits(surfaceSR, SurfaceOffset);
+                    var minDistanceInMapUnits = GetAsMapUnits(surfaceSR, MinDistance);
+                    var maxDistanceInMapUnits = GetAsMapUnits(surfaceSR, MaxDistance);
+                    var horizontalStartAngleInDegrees = GetAngularDistanceFromTo(AngularUnitType, AngularTypes.DEGREES, LeftHorizontalFOV);
+                    var horizontalEndAngleInDegrees = GetAngularDistanceFromTo(AngularUnitType, AngularTypes.DEGREES, RightHorizontalFOV);
+                    var verticalUpperAngleInDegrees = GetAngularDistanceFromTo(AngularUnitType, AngularTypes.DEGREES, TopVerticalFOV);
+                    var verticalLowerAngleInDegrees = GetAngularDistanceFromTo(AngularUnitType, AngularTypes.DEGREES, BottomVerticalFOV);
+
+                    await FeatureClassHelper.UpdateShapeWithZ(ObserversLayerName, VisibilityLibrary.Properties.Resources.ZFieldName, observerOffsetInMapZUnits);
+
+                    await CreateMask(RLOSMaskLayerName, minDistanceInMapUnits, maxDistanceInMapUnits, horizontalStartAngleInDegrees,
+                        horizontalEndAngleInDegrees, surfaceSR, observerPoints);
+
+                    string maxRangeMaskFeatureClassName = CoreModule.CurrentProject.DefaultGeodatabasePath + System.IO.Path.DirectorySeparatorChar + FeatureDatasetName + System.IO.Path.DirectorySeparatorChar + RLOSMaskLayerName;
+                    var environments = Geoprocessing.MakeEnvironmentArray(mask: maxRangeMaskFeatureClassName, overwriteoutput: true);
+
+                    var rlosOutputLayer = CoreModule.CurrentProject.DefaultGeodatabasePath + System.IO.Path.DirectorySeparatorChar + RLOSOutputLayerName;
+
+
+                    success = await FeatureClassHelper.CreateVisibility(SelectedSurfaceName, ObserversLayerName,
+                        rlosOutputLayer,
+                        observerOffsetInMapZUnits, surfaceOffsetInMapZUnits,
+                        minDistanceInMapUnits, maxDistanceInMapUnits,
+                        horizontalStartAngleInDegrees, horizontalEndAngleInDegrees,
+                        verticalUpperAngleInDegrees, verticalLowerAngleInDegrees,
+                        ShowNonVisibleData,
+                        environments,
+                        false);
+
+                    if (!success)
+                        return false;
+
+                    var rlosConvertedPolygonsLayer = CoreModule.CurrentProject.DefaultGeodatabasePath + System.IO.Path.DirectorySeparatorChar + FeatureDatasetName + System.IO.Path.DirectorySeparatorChar + RLOSConvertedPolygonsLayerName;
+
+                    string rangeFanMaskFeatureClassName = string.Empty;
+                    if ((MinDistance > 0) || !((horizontalStartAngleInDegrees == 0.0) && (horizontalEndAngleInDegrees == 360.0)))
+                    {
+                        string RLOSRangeFanMaskLayerName = "RangeFan_" + RLOSMaskLayerName;
+                        rangeFanMaskFeatureClassName = CoreModule.CurrentProject.DefaultGeodatabasePath + System.IO.Path.DirectorySeparatorChar + FeatureDatasetName + System.IO.Path.DirectorySeparatorChar + RLOSRangeFanMaskLayerName;
+
+                        await CreateMask(RLOSRangeFanMaskLayerName, minDistanceInMapUnits, maxDistanceInMapUnits, horizontalStartAngleInDegrees,
+                            horizontalEndAngleInDegrees, surfaceSR, observerPoints, true);
+                    }
+
+                    success = await FeatureClassHelper.IntersectOutput(rlosOutputLayer, rlosConvertedPolygonsLayer, false, "Value", rangeFanMaskFeatureClassName);
+                    if (!success)
+                        return false;
                 }
 
-                success = await FeatureClassHelper.IntersectOutput(rlosOutputLayer, rlosConvertedPolygonsLayer, false, "Value", rangeFanMaskFeatureClassName);
-                if (!success)
-                    return false;
+                // add observer points present out of extent to feature layer
+                var outOfExtent = new ObservableCollection<AddInPoint>(RLOS_ObserversOutOfExtent.Select(x => x.AddInPoint));
+                await FeatureClassHelper.CreatingFeatures(ObserversLayerName, outOfExtent, GetAsMapZUnits(surfaceSR, ObserverOffset.Value), VisibilityLibrary.Properties.Resources.IsOutOfExtentFieldName);
 
                 await FeatureClassHelper.CreateUniqueValueRenderer(GetLayerFromMapByName(RLOSConvertedPolygonsLayerName) as FeatureLayer, ShowNonVisibleData, RLOSConvertedPolygonsLayerName);
+
+                var observersLayer = GetLayerFromMapByName(ObserversLayerName) as FeatureLayer;
+
+                if (observersLayer != null)
+                {
+                    await FeatureClassHelper.CreateRLOSObserversRenderer(observersLayer as FeatureLayer);
+                }
+
+                await FeatureClassHelper.Delete(RLOSOutputLayerName);
+                //await FeatureClassHelper.Delete(RLOSMaskLayerName);
 
                 // Eventually we will add the new layers to a new group layer for each run
                 // Currently not working in current release of Pro.  
                 // From Roshan Herbert - I just spoke with the Dev who wrote the MoveLayer method. Apparently this a known issue. 
                 //                       We have bug to fix this and plan to fix it in the next release.
                 List<Layer> layerList = new List<Layer>();
-                layerList.Add(GetLayerFromMapByName(ObserversLayerName));
-                //layerList.Add(GetLayerFromMapByName(RLOSConvertedPolygonsLayerName));
+                var observersLayerFromMap = GetLayerFromMapByName(ObserversLayerName);
+                var RLOSConvertedPolygonsLayer = GetLayerFromMapByName(RLOSConvertedPolygonsLayerName);
                 
+                if (observersLayerFromMap != null)
+                    layerList.Add(observersLayerFromMap);
+                if (RLOSConvertedPolygonsLayer != null)
+                    layerList.Add(GetLayerFromMapByName(RLOSConvertedPolygonsLayerName));
+                
+                await FeatureClassHelper.MoveLayersToGroupLayer(layerList, FeatureDatasetName);
+
                 //string groupName = "RLOS Group";
                 //if (executionCounter > 0)
                 //    groupName = string.Format("{0}_{1}", groupName, executionCounter.ToString());
@@ -430,8 +528,8 @@ namespace ProAppVisibilityModule.ViewModels
                     await ZoomToExtent(envelope);
                 }
 
-                executionCounter++;
-
+                var surfaceEnvelope = await GetSurfaceEnvelope();
+                await DisplayOutOfExtentMsg();
                 success = true;
             }
             catch (Exception ex)
@@ -443,6 +541,43 @@ namespace ProAppVisibilityModule.ViewModels
             return success;
         }
 
+
+        private async Task DisplayOutOfExtentMsg()
+        {
+            await QueuedTask.Run(() =>
+            {
+                var observerIDCollection = RLOS_ObserversOutOfExtent.Select(x => x.ID).ToList<int>();
+                var observerString = string.Empty;
+                var targetString = string.Empty;
+                foreach (var item in observerIDCollection)
+                {
+                    if (observerString == "")
+                        observerString = item.ToString();
+                    else
+                        observerString = observerString + "," + item.ToString();
+                }
+                if (observerIDCollection.Any())
+                {
+                    if (observerIDCollection.Count <= 10)
+                    {
+                        var msgString = string.Empty;
+                        if (observerIDCollection.Any())
+                        {
+                            msgString = "Observers lying outside the extent of elevation surface are: " + observerString;
+                        }
+                        ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show(msgString,
+                                                    "Unable To Process For Few Locations");
+                    }
+                    else
+                    {
+                        ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show(VisibilityLibrary.Properties.Resources.LLOSPointsOutsideOfSurfaceExtent,
+                        VisibilityLibrary.Properties.Resources.MsgCalcCancelled);
+                    }
+
+                }
+            });
+        }
+
         /// <summary>
         /// Method used to create a mask for geoprocessing environment
         /// Will buffer around each observer at the max distance to create mask
@@ -450,13 +585,14 @@ namespace ProAppVisibilityModule.ViewModels
         /// <param name="maskFeatureClassName"></param>
         /// <param name="bufferDistance"></param>
         /// <returns>Task</returns>
-        private async Task CreateMask(string maskFeatureClassName, 
-            double minDistanceInMapUnits, double maxDistanceInMapUnits, 
-            double horizontalStartAngleInDegrees, double horizontalEndAngleInDegrees, 
-            SpatialReference surfaceSR, bool constructRangeFans = false)
+        private async Task CreateMask(string maskFeatureClassName,
+            double minDistanceInMapUnits, double maxDistanceInMapUnits,
+            double horizontalStartAngleInDegrees, double horizontalEndAngleInDegrees,
+            SpatialReference surfaceSR, ObservableCollection<AddInPoint> observerPoints,
+            bool constructRangeFans = false)
         {
             // create new
-            await FeatureClassHelper.CreateLayer(maskFeatureClassName, "POLYGON", false, false);
+            await FeatureClassHelper.CreateLayer(FeatureDatasetName, maskFeatureClassName, "POLYGON", false, false);
 
             try
             {
@@ -471,42 +607,42 @@ namespace ProAppVisibilityModule.ViewModels
                         EditOperation editOperation = new EditOperation();
                         editOperation.Callback(context =>
                         {
-                        try
-                        {
-                            var shapeFieldName = fcDefinition.GetShapeField();
-
-                            foreach (var observer in ObserverAddInPoints)
+                            try
                             {
-                                using (var rowBuffer = enterpriseFeatureClass.CreateRowBuffer())
+                                var shapeFieldName = fcDefinition.GetShapeField();
+
+                                foreach (var observer in observerPoints)
                                 {
-                                    // Either the field index or the field name can be used in the indexer.
-                                    // project the point here or the buffer tool may use an angular unit and run forever
-                                    var point = GeometryEngine.Instance.Project(observer.Point, surfaceSR);
-                                    Geometry polygon = null;
-
-                                    if (constructRangeFans)
+                                    using (var rowBuffer = enterpriseFeatureClass.CreateRowBuffer())
                                     {
-                                        polygon = GeometryHelper.ConstructRangeFan(point as MapPoint,
-                                            minDistanceInMapUnits, maxDistanceInMapUnits, horizontalStartAngleInDegrees,
-                                            horizontalEndAngleInDegrees, surfaceSR);                                       
-                                    }
-                                    else
-                                    {
-                                        polygon = GeometryEngine.Instance.Buffer(point, maxDistanceInMapUnits);
-                                    }
+                                        // Either the field index or the field name can be used in the indexer.
+                                        // project the point here or the buffer tool may use an angular unit and run forever
+                                        var point = GeometryEngine.Instance.Project(observer.Point, surfaceSR);
+                                        Geometry polygon = null;
 
-                                    rowBuffer[shapeFieldName] = polygon;
+                                        if (constructRangeFans)
+                                        {
+                                            polygon = GeometryHelper.ConstructRangeFan(point as MapPoint,
+                                                minDistanceInMapUnits, maxDistanceInMapUnits, horizontalStartAngleInDegrees,
+                                                horizontalEndAngleInDegrees, surfaceSR);
+                                        }
+                                        else
+                                        {
+                                            polygon = GeometryEngine.Instance.Buffer(point, maxDistanceInMapUnits);
+                                        }
 
-                                    Feature feature = enterpriseFeatureClass.CreateRow(rowBuffer);
-                                    feature.Store();
-                                    context.Invalidate(feature);
-                                } // using
-                            } // for each 
-                        }
-                        catch (GeodatabaseException exObj)
-                        {
-                            message = exObj.Message;
-                        }
+                                        rowBuffer[shapeFieldName] = polygon;
+
+                                        Feature feature = enterpriseFeatureClass.CreateRow(rowBuffer);
+                                        feature.Store();
+                                        context.Invalidate(feature);
+                                    } // using
+                                } // for each 
+                            }
+                            catch (GeodatabaseException exObj)
+                            {
+                                message = exObj.Message;
+                            }
                         }, enterpriseFeatureClass);
 
                         creationResult = await editOperation.ExecuteAsync();
@@ -558,6 +694,19 @@ namespace ProAppVisibilityModule.ViewModels
             }
 
             return Math.Round(angularDistance, 1);
+        }
+
+        private async Task ReadSelectedLayers()
+        {
+            var observerPoints = new ObservableCollection<MapPoint>();
+            RLOS_ObserversInExtent.Clear();
+            RLOS_ObserversOutOfExtent.Clear();
+
+            var surfaceEnvelope = await GetSurfaceEnvelope();
+            await QueuedTask.Run(() =>
+            {
+                ReadPointFromLayer(surfaceEnvelope, RLOS_ObserversInExtent, RLOS_ObserversOutOfExtent, SelectedRLOS_ObserverLyrName);
+            });
         }
 
         #endregion Private

--- a/source/addins/ProAppVisibilityModule/ViewModels/ProTabBaseViewModel.cs
+++ b/source/addins/ProAppVisibilityModule/ViewModels/ProTabBaseViewModel.cs
@@ -322,7 +322,7 @@ namespace ProAppVisibilityModule.ViewModels
                 {
                     await Reset(true);
                 });
-                
+
                 isActiveTab = value;
                 RaisePropertyChanged(() => IsActiveTab);
             }
@@ -488,7 +488,7 @@ namespace ProAppVisibilityModule.ViewModels
 
             RaisePropertyChanged(() => HasMapGraphics);
         }
-        
+
         /// <summary>
         /// Method used to totally reset the tool
         /// reset points, feedback
@@ -580,7 +580,7 @@ namespace ProAppVisibilityModule.ViewModels
                         var Lon = Double.Parse(matchMercator.Groups["longitude"].Value);
                         point = QueuedTask.Run(() =>
                             {
-                                return MapPointBuilder.CreateMapPoint(Lon, Lat);
+                                return MapPointBuilder.CreateMapPoint(Lon, Lat, MapView.Active.Map.SpatialReference);
                             }).Result;
                         return point;
                     }
@@ -613,7 +613,7 @@ namespace ProAppVisibilityModule.ViewModels
                 await QueuedTask.Run(() =>
                 {
                     // TODO add text graphic
-                    //var tg = new CIMTextGraphic() { Placement = Anchor.CenterPoint, Text = text};
+                    //var tg = new CIMTextGraphic() { Placement = Anchor.CenterPoint, Text = text};                    
                 });
             }
             else if (geom.GeometryType == GeometryType.Point)

--- a/source/addins/ProAppVisibilityModule/Views/ProSelectCoordinateFieldsView.xaml
+++ b/source/addins/ProAppVisibilityModule/Views/ProSelectCoordinateFieldsView.xaml
@@ -1,0 +1,79 @@
+<controls:ProWindow  x:Class="CoordinateConversionLibrary.Views.ProSelectCoordinateFieldsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:controls="clr-namespace:ArcGIS.Desktop.Framework.Controls;assembly=ArcGIS.Desktop.Framework"
+             xmlns:extensions="clr-namespace:ArcGIS.Desktop.Extensions;assembly=ArcGIS.Desktop.Extensions"                      
+             xmlns:local="clr-namespace:CoordinateConversionLibrary;assembly=CoordinateConversionLibrary"
+             xmlns:viewModels="clr-namespace:CoordinateConversionLibrary.ViewModels;assembly=CoordinateConversionLibrary"
+             xmlns:prop="clr-namespace:CoordinateConversionLibrary.Properties;assembly=CoordinateConversionLibrary"
+             xmlns:helpers="clr-namespace:CoordinateConversionLibrary.Helpers;assembly=CoordinateConversionLibrary"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
+             mc:Ignorable="d" 
+             WindowStartupLocation="CenterScreen"
+             Title="{x:Static prop:Resources.TitleSelectCoordinateFields}"
+             SizeToContent="WidthAndHeight"
+             helpers:DialogCloser.DialogResult="{Binding DialogResult}"
+                     d:DesignHeight="200" d:DesignWidth="420">
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <extensions:DesignOnlyResourceDictionary Source="pack://application:,,,/ArcGIS.Desktop.Framework;component\Themes\Default.xaml"/>
+                <ResourceDictionary Source="/CoordinateConversionLibrary;component/MAResourceDictionary.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+    <Window.Style>
+        <Style TargetType="Window" BasedOn="{StaticResource {x:Type Window}}">
+            <Setter Property="Background" Value="{DynamicResource Esri_DialogFrameBackgroundBrush}"/>
+        </Style>
+    </Window.Style>
+    <StackPanel Margin="20">
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" >
+            <TextBlock Margin="0,0,10,0" Text="{x:Static prop:Resources.LabelField1}" Style="{DynamicResource Esri_TextBlockRegular}" VerticalAlignment="Center" />
+            <ComboBox Height="Auto"
+                      Width="253"
+                      Margin="3,0,0,0"
+                      ItemsSource="{Binding AvailableFields}"
+                      SelectedItem="{Binding SelectedField1}"
+                      ItemContainerStyle="{StaticResource comboBoxItemStyle}">
+            </ComboBox>
+        </StackPanel>
+        <CheckBox x:Name="useTwoFields" Height="Auto" Margin="120,15,0,3" HorizontalAlignment="Left" IsChecked="{Binding UseTwoFields}">
+            <CheckBox.Content>
+                <TextBlock Text="{x:Static prop:Resources.UseTwoFields}" Style="{DynamicResource Esri_TextBlockRegular}" />
+            </CheckBox.Content>
+        </CheckBox>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="0,10,0,5">
+            <StackPanel.Style>
+                <Style TargetType="StackPanel">
+                    <Setter Property="IsEnabled" Value="False" />
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding ElementName=useTwoFields, Path=IsChecked}" Value="True">
+                            <Setter Property="IsEnabled" Value="True" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </StackPanel.Style>
+            <TextBlock Margin="0,0,10,0" Text="{x:Static prop:Resources.LabelField2}" Style="{DynamicResource Esri_TextBlockRegular}"  VerticalAlignment="Center"/>
+            <ComboBox Height="Auto"
+                      Width="253"
+                      Margin="15,0,0,0"
+                      ItemsSource="{Binding AvailableFields}"
+                      SelectedItem="{Binding SelectedField2}"
+                      ItemContainerStyle="{StaticResource comboBoxItemStyle}">
+            </ComboBox>
+        </StackPanel>
+        <StackPanel HorizontalAlignment="Right" Orientation="Horizontal" VerticalAlignment="Bottom">
+            <Button Command="{Binding OKButtonPressedCommand}"
+                    Content="{x:Static prop:Resources.ButtonOK}"
+                    IsCancel="False"
+                    IsEnabled="{Binding IsDialogComplete}" 
+                    Style="{DynamicResource Esri_Button}" />
+            <Button Content="{x:Static prop:Resources.ButtonCancel}"
+                    IsCancel="True" 
+                    Style="{DynamicResource Esri_Button}" />
+        </StackPanel>
+    </StackPanel>
+</controls:ProWindow>

--- a/source/addins/ProAppVisibilityModule/Views/ProSelectCoordinateFieldsView.xaml.cs
+++ b/source/addins/ProAppVisibilityModule/Views/ProSelectCoordinateFieldsView.xaml.cs
@@ -1,0 +1,15 @@
+using ArcGIS.Desktop.Framework.Controls;
+
+namespace CoordinateConversionLibrary.Views
+{
+    /// <summary>
+    /// Interaction logic for ProSelectCoordinateFieldsView.xaml
+    /// </summary>
+    public partial class ProSelectCoordinateFieldsView : ProWindow
+    {
+        public ProSelectCoordinateFieldsView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/source/addins/VisibilityLibrary/Properties/Resources.Designer.cs
+++ b/source/addins/VisibilityLibrary/Properties/Resources.Designer.cs
@@ -151,6 +151,15 @@ namespace VisibilityLibrary.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enter Manually.
+        /// </summary>
+        public static string EnterManuallyOption {
+            get {
+                return ResourceManager.GetString("EnterManuallyOption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to DD.
         /// </summary>
         public static string EnumCTDD {
@@ -358,6 +367,24 @@ namespace VisibilityLibrary.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to gridcode.
+        /// </summary>
+        public static string GridCodeFieldName {
+            get {
+                return ResourceManager.GetString("GridCodeFieldName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to IsOutOfExtent.
+        /// </summary>
+        public static string IsOutOfExtentFieldName {
+            get {
+                return ResourceManager.GetString("IsOutOfExtentFieldName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cancel.
         /// </summary>
         public static string LabelCancel {
@@ -408,6 +435,15 @@ namespace VisibilityLibrary.Properties {
         public static string LabelHorizontalFOV {
             get {
                 return ResourceManager.GetString("LabelHorizontalFOV", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Import.
+        /// </summary>
+        public static string LabelImport {
+            get {
+                return ResourceManager.GetString("LabelImport", resourceCulture);
             }
         }
         
@@ -471,6 +507,15 @@ namespace VisibilityLibrary.Properties {
         public static string LabelOK {
             get {
                 return ResourceManager.GetString("LabelOK", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Paste.
+        /// </summary>
+        public static string LabelPaste {
+            get {
+                return ResourceManager.GetString("LabelPaste", resourceCulture);
             }
         }
         
@@ -543,6 +588,15 @@ namespace VisibilityLibrary.Properties {
         public static string LabelVerticalFOV {
             get {
                 return ResourceManager.GetString("LabelVerticalFOV", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to LLOS.
+        /// </summary>
+        public static string LLOSFeatureDatasetName {
+            get {
+                return ResourceManager.GetString("LLOSFeatureDatasetName", resourceCulture);
             }
         }
         
@@ -673,6 +727,15 @@ namespace VisibilityLibrary.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No data found.
+        /// </summary>
+        public static string MsgNoDataFound {
+            get {
+                return ResourceManager.GetString("MsgNoDataFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Point does not fall within the input extent..
         /// </summary>
         public static string MsgOutOfAOI {
@@ -732,6 +795,15 @@ namespace VisibilityLibrary.Properties {
         public static string RLOSConvertedPolygonsLayerName {
             get {
                 return ResourceManager.GetString("RLOSConvertedPolygonsLayerName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to RLOS.
+        /// </summary>
+        public static string RLOSFeatureDatasetName {
+            get {
+                return ResourceManager.GetString("RLOSFeatureDatasetName", resourceCulture);
             }
         }
         

--- a/source/addins/VisibilityLibrary/Properties/Resources.resx
+++ b/source/addins/VisibilityLibrary/Properties/Resources.resx
@@ -405,4 +405,28 @@
   <data name="MsgSurfaceLayerNotFound" xml:space="preserve">
     <value>The surface layer was not found. Please try again.</value>
   </data>
+  <data name="LabelImport" xml:space="preserve">
+    <value>Import</value>
+  </data>
+  <data name="LabelPaste" xml:space="preserve">
+    <value>Paste</value>
+  </data>
+  <data name="LLOSFeatureDatasetName" xml:space="preserve">
+    <value>LLOS</value>
+  </data>
+  <data name="RLOSFeatureDatasetName" xml:space="preserve">
+    <value>RLOS</value>
+  </data>
+  <data name="MsgNoDataFound" xml:space="preserve">
+    <value>No data found</value>
+  </data>
+  <data name="EnterManuallyOption" xml:space="preserve">
+    <value>Enter Manually</value>
+  </data>
+  <data name="IsOutOfExtentFieldName" xml:space="preserve">
+    <value>IsOutOfExtent</value>
+  </data>
+  <data name="GridCodeFieldName" xml:space="preserve">
+    <value>gridcode</value>
+  </data>
 </root>

--- a/source/addins/VisibilityLibrary/Views/LLOSView.xaml
+++ b/source/addins/VisibilityLibrary/Views/LLOSView.xaml
@@ -43,7 +43,17 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
+                <ProgressBar
+                    Name="pbStatus"
+                    Grid.ColumnSpan="3"
+                    Width="Auto"
+                    Margin="3,3,0,0"
+                    HorizontalAlignment="Stretch"
+                    IsIndeterminate="True"
+                    Visibility="{Binding DisplayProgressBarLLOS}" />
                 <TextBlock
                     Grid.ColumnSpan="3"
                     Margin="3,3,0,0"
@@ -75,8 +85,22 @@
                     Grid.ColumnSpan="3"
                     Margin="3,3,0,0"
                     Text="{x:Static prop:Resources.LabelObserverPoints}" />
-                <TextBox
+                <ComboBox
                     Grid.Row="3"
+                    Grid.ColumnSpan="3"
+                        Margin="3,3,0,0"
+                        ItemsSource="{Binding LLOS_ObserverLyrNames}"
+                        SelectedItem="{Binding SelectedLLOS_ObserverLyrName}">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel>
+                                <TextBlock Text="{Binding}" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+                <TextBox
+                    Grid.Row="4"
                     Grid.ColumnSpan="2"
                     Margin="3,3,0,0"
                     VerticalContentAlignment="Center"
@@ -91,7 +115,7 @@
                     </TextBox.InputBindings>
                 </TextBox>
                 <ToggleButton 
-                    Grid.Row="3"
+                    Grid.Row="4"
                     Grid.Column="2"
                     Margin="3,3,0,0"
                     HorizontalAlignment="Center"
@@ -118,7 +142,7 @@
                 </ToggleButton>
                 <ListBox
                     x:Name="listBoxObservers"
-                    Grid.Row="4"
+                    Grid.Row="5"
                     Grid.ColumnSpan="3"
                     Height="60"
                     Margin="3,3,0,0"
@@ -135,7 +159,15 @@
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                     <ListBox.ContextMenu>
-                        <ContextMenu DataContext="{Binding Path=PlacementTarget, RelativeSource={RelativeSource Self}}">
+                        <ContextMenu DataContext="{Binding Path=PlacementTarget, RelativeSource={RelativeSource Self}}">                           
+                            <MenuItem
+                                Command="{Binding DataContext.ImportCSVFileCommand}"
+                                CommandParameter="{x:Static prop:Resources.ToolModeObserver}"
+                                Header="{x:Static prop:Resources.LabelImport}"/>
+                            <MenuItem
+                                Command="{Binding DataContext.PasteCoordinatesCommand}"
+                                CommandParameter="{x:Static prop:Resources.ToolModeObserver}"
+                                Header="{x:Static prop:Resources.LabelPaste}"/>
                             <MenuItem
                                 Command="{Binding DataContext.DeletePointCommand}"
                                 CommandParameter="{Binding Path=SelectedItems}"
@@ -143,7 +175,7 @@
                             <MenuItem
                                 Command="{Binding DataContext.DeleteAllPointsCommand}"
                                 CommandParameter="{x:Static prop:Resources.ToolModeObserver}"
-                                Header="{x:Static prop:Resources.MenuLabelDeleteAll}" />
+                                Header="{x:Static prop:Resources.MenuLabelDeleteAll}" />                                                      
                         </ContextMenu>
                     </ListBox.ContextMenu>
                     <ListBox.InputBindings>
@@ -154,12 +186,26 @@
                     </ListBox.InputBindings>
                 </ListBox>
                 <TextBlock
-                    Grid.Row="5"
+                    Grid.Row="6"
                     Grid.ColumnSpan="3"
                     Margin="3,3,0,0"
                     Text="{x:Static prop:Resources.LabelTargetPoints}" />
+                <ComboBox
+                    Grid.Row="7"
+                    Grid.ColumnSpan="3"
+                        Margin="3,3,0,0"
+                        ItemsSource="{Binding LLOS_TargetLyrNames}"
+                        SelectedItem="{Binding SelectedLLOS_TargetLyrName}">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel>
+                                <TextBlock Text="{Binding}" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
                 <TextBox
-                    Grid.Row="6"
+                    Grid.Row="8"
                     Grid.ColumnSpan="2"
                     Margin="3,3,0,0"
                     VerticalContentAlignment="Center"
@@ -174,7 +220,7 @@
                     </TextBox.InputBindings>
                 </TextBox>
                 <ToggleButton
-                    Grid.Row="6"
+                    Grid.Row="8"
                     Grid.Column="2"
                     Margin="3,3,0,0"
                     HorizontalAlignment="Center"
@@ -201,7 +247,7 @@
                 </ToggleButton>
                 <ListBox
                     x:Name="listBoxTargets"
-                    Grid.Row="7"
+                    Grid.Row="9"
                     Grid.ColumnSpan="3"
                     Height="60"
                     Margin="3,3,0,0"
@@ -220,13 +266,21 @@
                     <ListBox.ContextMenu>
                         <ContextMenu DataContext="{Binding Path=PlacementTarget, RelativeSource={RelativeSource Self}}">
                             <MenuItem
+                                Command="{Binding DataContext.ImportCSVFileCommand}"
+                                CommandParameter="{x:Static prop:Resources.ToolModeTarget}"
+                                Header="{x:Static prop:Resources.LabelImport}"/>
+                            <MenuItem
+                                Command="{Binding DataContext.PasteCoordinatesCommand}"
+                                CommandParameter="{x:Static prop:Resources.ToolModeTarget}"
+                                Header="{x:Static prop:Resources.LabelPaste}"/>
+                            <MenuItem
                                 Command="{Binding DataContext.DeletePointCommand}"
                                 CommandParameter="{Binding Path=SelectedItems}"
                                 Header="{x:Static prop:Resources.MenuLabelDelete}" />
                             <MenuItem
                                 Command="{Binding DataContext.DeleteAllPointsCommand}"
                                 CommandParameter="{x:Static prop:Resources.ToolModeTarget}"
-                                Header="{x:Static prop:Resources.MenuLabelDeleteAll}" />
+                                Header="{x:Static prop:Resources.MenuLabelDeleteAll}" />                            
                         </ContextMenu>
                     </ListBox.ContextMenu>
                     <ListBox.InputBindings>
@@ -235,9 +289,9 @@
                             Command="{Binding DeletePointCommand}"
                             CommandParameter="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListBox}}, Path=SelectedItems}" />
                     </ListBox.InputBindings>
-                </ListBox>
+                </ListBox>              
                 <GroupBox
-                    Grid.Row="8"
+                    Grid.Row="10"
                     Grid.ColumnSpan="4"
                     Margin="0,3,0,0"
                     Header="{x:Static prop:Resources.LabelOffsets}">
@@ -266,12 +320,12 @@
                     </StackPanel>
                 </GroupBox>
                 <StackPanel
-                    Grid.Row="14"
+                    Grid.Row="16"
                     Grid.ColumnSpan="3"
                     HorizontalAlignment="Right"
-                    Orientation="Horizontal">
+                    Orientation="Horizontal">                     
                     <Button
-                        Grid.Row="14"
+                        Grid.Row="16"
                         Grid.Column="0"
                         Width="60"
                         Margin="3,20,0,0"
@@ -300,12 +354,20 @@
                                             <Setter Property="IsEnabled" Value="True" />
                                         </MultiDataTrigger.Setters>
                                     </MultiDataTrigger>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding IsLLOSValidSelection}" Value="True" />
+                                        </MultiDataTrigger.Conditions>
+                                        <MultiDataTrigger.Setters>
+                                            <Setter Property="IsEnabled" Value="True" />
+                                        </MultiDataTrigger.Setters>
+                                    </MultiDataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </Button.Style>
                     </Button>
                     <Button
-                        Grid.Row="14"
+                        Grid.Row="16"
                         Grid.Column="1"
                         Width="60"
                         Margin="3,20,0,0"
@@ -328,12 +390,20 @@
                                             <Setter Property="IsEnabled" Value="True" />
                                         </MultiDataTrigger.Setters>
                                     </MultiDataTrigger>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding IsLLOSValidSelection}" Value="True" />
+                                        </MultiDataTrigger.Conditions>
+                                        <MultiDataTrigger.Setters>
+                                            <Setter Property="IsEnabled" Value="True" />
+                                        </MultiDataTrigger.Setters>
+                                    </MultiDataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </Button.Style>
                     </Button>
                     <Button
-                        Grid.Row="14"
+                        Grid.Row="16"
                         Grid.Column="2"
                         Margin="3,20,0,0"
                         Command="{Binding ClearGraphicsCommand}"

--- a/source/addins/VisibilityLibrary/Views/RLOSView.xaml
+++ b/source/addins/VisibilityLibrary/Views/RLOSView.xaml
@@ -37,6 +37,7 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
                 <ProgressBar
@@ -83,8 +84,22 @@
                     Margin="3,3,0,0"
                     HorizontalAlignment="Stretch"
                     Text="{x:Static prop:Resources.LabelObserverPoints}" />
-                <TextBox
+                <ComboBox
                     Grid.Row="3"
+                    Grid.ColumnSpan="3"
+                        Margin="3,3,0,0"
+                        ItemsSource="{Binding RLOS_ObserverLyrNames}"
+                        SelectedItem="{Binding SelectedRLOS_ObserverLyrName}">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel>
+                                <TextBlock Text="{Binding}" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+                <TextBox
+                    Grid.Row="4"
                     Grid.ColumnSpan="2"
                     Margin="3,3,0,0"
                     VerticalContentAlignment="Center"
@@ -100,7 +115,7 @@
                 </TextBox>
 
                 <ToggleButton
-                    Grid.Row="3"
+                    Grid.Row="4"
                     Grid.Column="2"
                     Margin="3,3,0,0"
                     HorizontalAlignment="Center"
@@ -128,7 +143,7 @@
                 </ToggleButton>
                 <ListBox
                     x:Name="listBoxObservers"
-                    Grid.Row="4"
+                    Grid.Row="5"
                     Grid.ColumnSpan="3"
                     Height="60"
                     Margin="3,3,0,0"
@@ -146,6 +161,14 @@
                     </ListBox.ItemTemplate>
                     <ListBox.ContextMenu>
                         <ContextMenu DataContext="{Binding Path=PlacementTarget, RelativeSource={RelativeSource Self}}">
+                            <MenuItem
+                                Command="{Binding DataContext.ImportCSVFileCommand}"
+                                CommandParameter="{x:Static prop:Resources.ToolModeObserver}"
+                                Header="{x:Static prop:Resources.LabelImport}"/>
+                            <MenuItem
+                                Command="{Binding DataContext.PasteCoordinatesCommand}"
+                                CommandParameter="{x:Static prop:Resources.ToolModeObserver}"
+                                  Header="{x:Static prop:Resources.LabelPaste}"/>
                             <MenuItem
                                 Command="{Binding DataContext.DeletePointCommand}"
                                 CommandParameter="{Binding Path=SelectedItems}"
@@ -165,7 +188,7 @@
                 </ListBox>
 
                 <CheckBox
-                    Grid.Row="5"
+                    Grid.Row="6"
                     Grid.ColumnSpan="3"
                     Margin="3,9,0,0"
                     HorizontalAlignment="Left"
@@ -185,7 +208,7 @@
                     </CheckBox.Style>
                 </CheckBox>
                 <StackPanel
-                    Grid.Row="6"
+                    Grid.Row="7"
                     Grid.ColumnSpan="3"
                     HorizontalAlignment="Right"
                     Orientation="Horizontal">
@@ -203,6 +226,14 @@
                                         <MultiDataTrigger.Conditions>
                                             <Condition Binding="{Binding ElementName=listBoxObservers, Path=HasItems}" Value="True" />
                                             <Condition Binding="{Binding IsRunning}" Value="False" />
+                                        </MultiDataTrigger.Conditions>
+                                        <MultiDataTrigger.Setters>
+                                            <Setter Property="IsEnabled" Value="True" />
+                                        </MultiDataTrigger.Setters>
+                                    </MultiDataTrigger>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding IsRLOSValidSelection}" Value="True" />
                                         </MultiDataTrigger.Conditions>
                                         <MultiDataTrigger.Setters>
                                             <Setter Property="IsEnabled" Value="True" />
@@ -240,6 +271,14 @@
                                             <Setter Property="IsEnabled" Value="True" />
                                         </MultiDataTrigger.Setters>
                                     </MultiDataTrigger>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding IsRLOSValidSelection}" Value="True" />
+                                        </MultiDataTrigger.Conditions>
+                                        <MultiDataTrigger.Setters>
+                                            <Setter Property="IsEnabled" Value="True" />
+                                        </MultiDataTrigger.Setters>
+                                    </MultiDataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </Button.Style>
@@ -262,9 +301,9 @@
                         </Button.Style>
                     </Button>
                 </StackPanel>
-
+                
                 <Expander
-                    Grid.Row="7"
+                    Grid.Row="8"
                     Grid.ColumnSpan="3"
                     Margin="3,3,0,0"
                     HorizontalAlignment="Stretch"
@@ -338,16 +377,17 @@
                             </StackPanel>
                         </GroupBox>
                         <GroupBox
-                            Grid.Row="5"
+                            Grid.Row="6"
                             Grid.ColumnSpan="4"
                             Header="{x:Static prop:Resources.LabelDistance}">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <TextBox
+                            <StackPanel>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBox
                                     x:Name="tbMinDistance"
                                     Grid.Column="0"
                                     Margin="3,3,0,0"
@@ -355,17 +395,17 @@
                                     Style="{StaticResource textboxStyle}"
                                     Text="{Binding MinDistance, UpdateSourceTrigger=PropertyChanged, ValidatesOnExceptions=True}"
                                     Validation.ErrorTemplate="{StaticResource errorTemplate}">
-                                    <TextBox.InputBindings>
-                                        <KeyBinding Key="Enter" Command="{Binding EnterKeyCommand}" />
-                                    </TextBox.InputBindings>
-                                </TextBox>
-                                <TextBlock
+                                        <TextBox.InputBindings>
+                                            <KeyBinding Key="Enter" Command="{Binding EnterKeyCommand}" />
+                                        </TextBox.InputBindings>
+                                    </TextBox>
+                                    <TextBlock
                                     Grid.Column="1"
                                     Margin="3,3,0,0"
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
                                     Text="{x:Static prop:Resources.LabelTo}" />
-                                <TextBox
+                                    <TextBox
                                     x:Name="tbMaxDistance"
                                     Grid.Column="2"
                                     Margin="3,3,0,0"
@@ -373,15 +413,24 @@
                                     Style="{StaticResource textboxStyle}"
                                     Text="{Binding MaxDistance, UpdateSourceTrigger=PropertyChanged, ValidatesOnExceptions=True}"
                                     Validation.ErrorTemplate="{StaticResource errorTemplate}">
-                                    <TextBox.InputBindings>
-                                        <KeyBinding Key="Enter" Command="{Binding EnterKeyCommand}" />
-                                    </TextBox.InputBindings>
-                                </TextBox>
-                            </Grid>
+                                        <TextBox.InputBindings>
+                                            <KeyBinding Key="Enter" Command="{Binding EnterKeyCommand}" />
+                                        </TextBox.InputBindings>
+                                    </TextBox>
+                                </Grid>
+                                <ComboBox
+                                    x:Name="cmbDistanceUnitType"
+                                    Width="Auto"
+                                    Height="Auto"
+                                    Margin="3,3,0,0"
+                                    ItemsSource="{Binding Source={StaticResource lineDistanceData}}"
+                                    SelectedItem="{Binding Path=DistanceUnitType, Mode=TwoWay}">
+                                </ComboBox>
+                            </StackPanel>
                         </GroupBox>
 
                         <GroupBox
-                            Grid.Row="6"
+                            Grid.Row="7"
                             Grid.ColumnSpan="4"
                             Header="{x:Static prop:Resources.LabelFieldOfView}">
                             <Grid>


### PR DESCRIPTION
This build addresses the GitHub tickets mentioned below:

#281 - Store LLOS and RLOS results in a organized fashion
#279 - Use a spreadsheet of values as inputs
#242 - RLOS - Cutting off viewsheds when a user brings in a non projected data layer
#172 - Select [an] existing feature(s) as inputs
#123 - RLOS: Distance parameter does not have a dedicated units control (ArcGIS Pro)
#122 - RLOS: Distance parameter does not have a dedicated units control (ArcMap)
#120 - LLOS: add progress bar similar to RLOS (ArcGIS Pro)