### PR TITLE
Delivery of Visibility Addin DotNet – Sprint 3(Updates)

### DIFF
--- a/source/addins/ProAppVisibilityModule/Helpers/FeatureClassHelper.cs
+++ b/source/addins/ProAppVisibilityModule/Helpers/FeatureClassHelper.cs
@@ -961,14 +961,14 @@ namespace ProAppVisibilityModule.Helpers
                 uniqueValueRenderer.Groups = new CIMUniqueValueGroup[] { groupOne };
 
                 //Draw the rest with the default symbol
-                uniqueValueRenderer.UseDefaultSymbol = true;
-                uniqueValueRenderer.DefaultLabel = "All other values";
+                //uniqueValueRenderer.UseDefaultSymbol = true;
+                //uniqueValueRenderer.DefaultLabel = "All other values";
 
-                var defaultColor = CIMColor.CreateRGBColor(215, 215, 215);
-                uniqueValueRenderer.DefaultSymbol = new CIMSymbolReference()
-                {
-                    Symbol = SymbolFactory.Instance.ConstructPointSymbol(defaultColor)
-                };
+                //var defaultColor = CIMColor.CreateRGBColor(215, 215, 215);
+                //uniqueValueRenderer.DefaultSymbol = new CIMSymbolReference()
+                //{
+                //    Symbol = SymbolFactory.Instance.ConstructPointSymbol(defaultColor)
+                //};
 
                 //var renderer = featureLayer.CreateRenderer(uniqueValueRenderer);
                 featureLayer.SetRenderer(uniqueValueRenderer);

--- a/source/addins/ProAppVisibilityModule/ProAppVisibilityModule.csproj
+++ b/source/addins/ProAppVisibilityModule/ProAppVisibilityModule.csproj
@@ -53,12 +53,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ESRI.ArcGIS.Display, Version=10.3.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="ESRI.ArcGIS.GraphicsSymbols, Version=10.3.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/source/addins/ProAppVisibilityModule/ViewModels/ProLLOSViewModel.cs
+++ b/source/addins/ProAppVisibilityModule/ViewModels/ProLLOSViewModel.cs
@@ -35,7 +35,6 @@ using VisibilityLibrary.Helpers;
 using ArcGIS.Core.Data;
 using System.Text.RegularExpressions;
 using ArcGIS.Core.CIM;
-using ESRI.ArcGIS.Display;
 
 namespace ProAppVisibilityModule.ViewModels
 {
@@ -576,8 +575,8 @@ namespace ProAppVisibilityModule.ViewModels
                     List<Layer> lyrList = new List<Layer>();
                     lyrList.Add(observersLayer);
                     lyrList.Add(targetsLayer);
-                    lyrList.Add(sightLinesLayer);
                     lyrList.Add(outputLayer);
+                    lyrList.Add(sightLinesLayer);
 
                     await FeatureClassHelper.MoveLayersToGroupLayer(lyrList, FeatureDatasetName);
                     var envelope = await QueuedTask.Run(() => outputLayer.QueryExtent());


### PR DESCRIPTION
This release addresses:
1) Removed the erroneously added references as highlighted here: https://github.com/Esri/visibility-addin-dotnet/commit/573fa78bd008acf2c95e4824da145cb07559b157#commitcomment-29851089
2) Removed "All other values" and changed the order of layers as mentioned in https://github.com/Esri/visibility-addin-dotnet/issues/281