### PR TITLE
Delivery of Visibility Addin DotNet V2 - Sprint 1 of 1

### DIFF
--- a/source/addins/ArcMapAddinVisibility/ViewModels/LOSBaseViewModel.cs
+++ b/source/addins/ArcMapAddinVisibility/ViewModels/LOSBaseViewModel.cs
@@ -1101,13 +1101,12 @@ namespace ArcMapAddinVisibility.ViewModels
                     {
                         var value = feature.get_Value(FLayer.FeatureClass.FindField("Shape"));
                         var point = (IPoint)value;
-                        var guid = AddGraphicToMap(point, color, true, esriSimpleMarkerStyle.esriSMSSquare);
                         var objectId = FLayer.FeatureClass.FindField("ObjectId");
                         var FID = FLayer.FeatureClass.FindField("FID");
                         var idIndex = objectId != -1 ? objectId : FID;
                         var id = Convert.ToInt32(feature.get_Value(idIndex));
                         var z1 = surface.GetElevation(point) + finalObserverOffset;
-                        var addInPoint = new AddInPoint() { Point = point, GUID = guid };
+                        var addInPoint = new AddInPoint() { Point = point, GUID = Guid.NewGuid().ToString() };
                         if (selectedFeaturesCollections == null || !selectedFeaturesCollections.Any() ||
                             (selectedFeaturesCollections.Any() && selectedFeaturesCollections.Where(x => x == id).Any()))
                         {

--- a/source/addins/ArcMapAddinVisibility/ViewModels/RLOSViewModel.cs
+++ b/source/addins/ArcMapAddinVisibility/ViewModels/RLOSViewModel.cs
@@ -599,8 +599,8 @@ namespace ArcMapAddinVisibility.ViewModels
 
                         DisplayOutOfExtentMsg(selectedLayer);
                         //display point present out of extent
-                        var colorObserver = new RgbColorClass() { Red = 255 };
-                        var colorBorder = new RgbColorClass() { Red = 0, Blue = 0, Green = 0 };
+                        var colorObserver = new RgbColorClass() { Blue = 255 };
+                        var colorBorder = new RgbColorClass() { Red = 255, Blue = 255, Green = 255 };
                         var observerOutOfExtent = new ObservableCollection<AddInPoint>(RLOS_ObserversOutOfExtent.Select(x => x.AddInPoint).Union(ObserverOutExtentPoints));
                         foreach (var point in observerOutOfExtent)
                         {

--- a/source/addins/ArcMapAddinVisibility/ViewModels/RLOSViewModel.cs
+++ b/source/addins/ArcMapAddinVisibility/ViewModels/RLOSViewModel.cs
@@ -154,6 +154,7 @@ namespace ArcMapAddinVisibility.ViewModels
         }
 
         public bool ShowNonVisibleData { get; set; }
+        public bool ShowClassicViewshed { get; set; }
         public int RunCount { get; set; }
 
         private Visibility _displayProgressBar;
@@ -685,19 +686,34 @@ namespace ArcMapAddinVisibility.ViewModels
                 fillSymbol2.Color = new RgbColorClass() { Green = 255 } as IColor;
                 fillSymbol2.Outline = outlineSymbol;
                 uvRenderer.AddValue("1", "", fillSymbol2 as ISymbol);
-                uvRenderer.set_Label("1", "Visible by 1 Observer");
+               
+                if (ShowClassicViewshed)
+                {
+                    uvRenderer.set_Label("1", "Visible");
+                }
+                else
+                {
+                    uvRenderer.set_Label("1", "Visible by 1 Observer");
+                }
 
                 int field = ipTable.FindField("gridcode");
                 uvRenderer.set_Field(0, "gridcode");
 
                 for (int i = 2; i < uniqueValues; i++)
                 {
-                    ISimpleFillSymbol newFillSymbol = new SimpleFillSymbolClass();
-                    newFillSymbol.Color = colorRamp.get_Color(i);
-                    newFillSymbol.Outline = outlineSymbol;
-                    uvRenderer.AddValue(i.ToString(), "", newFillSymbol as ISymbol);
-                    string label = "Visible by " + i.ToString() + " Observers";
-                    uvRenderer.set_Label(i.ToString(), label);
+                    if (ShowClassicViewshed)
+                    {
+                        uvRenderer.AddReferenceValue(i.ToString(),"1");
+                    }
+                    else
+                    {
+                        ISimpleFillSymbol newFillSymbol = new SimpleFillSymbolClass();
+                        newFillSymbol.Color = colorRamp.get_Color(i);
+                        newFillSymbol.Outline = outlineSymbol;
+                        uvRenderer.AddValue(i.ToString(), "", newFillSymbol as ISymbol);
+                        string label = "Visible by " + i.ToString() + " Observers";
+                        uvRenderer.set_Label(i.ToString(), label);
+                    }
                 }
 
                 return featRenderer;

--- a/source/addins/ProAppVisibilityModule/Helpers/FeatureClassHelper.cs
+++ b/source/addins/ProAppVisibilityModule/Helpers/FeatureClassHelper.cs
@@ -967,7 +967,7 @@ namespace ProAppVisibilityModule.Helpers
                 outOfExtentValues.Add(outOfExtentValue);
 
                 var outExtentSymbol = SymbolFactory.Instance.ConstructPointSymbol();
-                var symbol = SymbolFactory.Instance.ConstructMarker(CIMColor.CreateRGBColor(255, 0, 0), 12, SimpleMarkerStyle.X);
+                var symbol = SymbolFactory.Instance.ConstructMarker(CIMColor.CreateRGBColor(0, 0, 255), 12, SimpleMarkerStyle.X);
                 outExtentSymbol.SymbolLayers = new CIMSymbolLayer[1] { symbol };
 
                 var outOfExtent = new CIMUniqueValueClass()
@@ -1038,7 +1038,7 @@ namespace ProAppVisibilityModule.Helpers
                 outOfExtentValues.Add(outOfExtentValue);
 
                 var outExtentSymbol = SymbolFactory.Instance.ConstructPointSymbol();
-                var symbol = SymbolFactory.Instance.ConstructMarker(CIMColor.CreateRGBColor(0, 0, 255), 12, SimpleMarkerStyle.X);
+                var symbol = SymbolFactory.Instance.ConstructMarker(CIMColor.CreateRGBColor(255, 0, 0), 12, SimpleMarkerStyle.X);
                 outExtentSymbol.SymbolLayers = new CIMSymbolLayer[1] { symbol };
 
                 var outOfExtent = new CIMUniqueValueClass()

--- a/source/addins/ProAppVisibilityModule/Helpers/FeatureClassHelper.cs
+++ b/source/addins/ProAppVisibilityModule/Helpers/FeatureClassHelper.cs
@@ -437,7 +437,7 @@ namespace ProAppVisibilityModule.Helpers
         /// <param name="featureLayer"></param>
         /// <param name="showNonVisData">flag to show non visible data as RED or transparent</param>
         /// <returns></returns>
-        public static async Task CreateUniqueValueRenderer(FeatureLayer featureLayer, bool showNonVisData, string outputLayerName)
+        public static async Task CreateUniqueValueRenderer(FeatureLayer featureLayer, bool showNonVisData, string outputLayerName, bool showClassicViewshed)
         {
             if (featureLayer == null)
                 return;
@@ -483,10 +483,19 @@ namespace ProAppVisibilityModule.Helpers
 
                 List<CIMUniqueValueClass> classes = new List<CIMUniqueValueClass>();
 
+                List<CIMUniqueValue> visibleValues = new List<CIMUniqueValue>();
                 int cnt = 1;
                 foreach (var gc in gridcodeUniqueList)
                 {
-                    colors.MoveNext();
+                    if (showClassicViewshed)
+                    {
+                        CIMUniqueValue visibleValue = new CIMUniqueValue();
+                        visibleValue.FieldValues = new string[] { gc.ToString() };
+                        visibleValues.Add(visibleValue);
+                    }
+                    else
+                    {
+                        colors.MoveNext();
 
                     List<CIMUniqueValue> visValues = new List<CIMUniqueValue>();
                     CIMUniqueValue visValue = new CIMUniqueValue();
@@ -505,10 +514,27 @@ namespace ProAppVisibilityModule.Helpers
                         Symbol = new CIMSymbolReference() { Symbol = visSymbol }
                     };
 
-                    classes.Add(visClass);
-                    cnt++;
+                        classes.Add(visClass);
+                        cnt++;
+                    }
                 }
 
+                if (showClassicViewshed)
+                {
+                    var visibleSymbol = SymbolFactory.Instance.ConstructPolygonSymbol(ColorFactory.Instance.GreenRGB);
+                    string visibleLabel = "Visible";
+                    var visibleClass = new CIMUniqueValueClass()
+                    {
+                        Values = visibleValues.ToArray(),
+                        Label = visibleLabel,
+                        Visible = true,
+                        Editable = true,
+                        Symbol = new CIMSymbolReference() { Symbol = visibleSymbol }
+                    };
+
+                    classes.Add(visibleClass);
+                }
+               
                 CIMUniqueValueGroup groupOne = new CIMUniqueValueGroup();
                 groupOne.Heading = "";
                 groupOne.Classes = classes.ToArray();
@@ -961,14 +987,14 @@ namespace ProAppVisibilityModule.Helpers
                 uniqueValueRenderer.Groups = new CIMUniqueValueGroup[] { groupOne };
 
                 //Draw the rest with the default symbol
-                //uniqueValueRenderer.UseDefaultSymbol = true;
-                //uniqueValueRenderer.DefaultLabel = "All other values";
+                uniqueValueRenderer.UseDefaultSymbol = true;
+                uniqueValueRenderer.DefaultLabel = "All other values";
 
-                //var defaultColor = CIMColor.CreateRGBColor(215, 215, 215);
-                //uniqueValueRenderer.DefaultSymbol = new CIMSymbolReference()
-                //{
-                //    Symbol = SymbolFactory.Instance.ConstructPointSymbol(defaultColor)
-                //};
+                var defaultColor = CIMColor.CreateRGBColor(215, 215, 215);
+                uniqueValueRenderer.DefaultSymbol = new CIMSymbolReference()
+                {
+                    Symbol = SymbolFactory.Instance.ConstructPointSymbol(defaultColor)
+                };
 
                 //var renderer = featureLayer.CreateRenderer(uniqueValueRenderer);
                 featureLayer.SetRenderer(uniqueValueRenderer);
@@ -992,7 +1018,7 @@ namespace ProAppVisibilityModule.Helpers
                 noVisValue.FieldValues = new string[] { "0" };
                 noVisValues.Add(noVisValue);
 
-                var noVisSymbol = SymbolFactory.Instance.ConstructPointSymbol(CIMColor.CreateRGBColor(255, 0, 0), 12, SimpleMarkerStyle.Circle);
+                var noVisSymbol = SymbolFactory.Instance.ConstructPointSymbol(CIMColor.CreateRGBColor(255, 0, 0), 14, SimpleMarkerStyle.Circle);
 
                 var noVis = new CIMUniqueValueClass()
                 {
@@ -1037,7 +1063,7 @@ namespace ProAppVisibilityModule.Helpers
 
                 uniqueValueRenderer.DefaultSymbol = new CIMSymbolReference()
                 {
-                    Symbol = SymbolFactory.Instance.ConstructPointSymbol(CIMColor.CreateRGBColor(0, 255, 0), 12, SimpleMarkerStyle.Circle)
+                    Symbol = SymbolFactory.Instance.ConstructPointSymbol(CIMColor.CreateRGBColor(0, 255, 0), 14, SimpleMarkerStyle.Circle)
                 };
 
                 //var renderer = featureLayer.CreateRenderer(uniqueValueRenderer);
@@ -1107,7 +1133,7 @@ namespace ProAppVisibilityModule.Helpers
                 //lc.SetExpression(string.Format("[{0}]", VisibilityLibrary.Properties.Resources.NumOfObserversFieldName));
                 string expression = @"Function FindLabel ( [NumOfObservers] )
                                     If (CInt([NumOfObservers])>0) Then
-                                        FindLabel = [NumOfObservers]
+                                        FindLabel = ""<FNT size='8'>"" + [NumOfObservers] + ""</FNT>""
                                     else
                                         FindLabel = """"
                                     End If

--- a/source/addins/ProAppVisibilityModule/Helpers/FeatureClassHelper.cs
+++ b/source/addins/ProAppVisibilityModule/Helpers/FeatureClassHelper.cs
@@ -1091,7 +1091,7 @@ namespace ProAppVisibilityModule.Helpers
                 outOfExtentValues.Add(outOfExtentValue);
 
                 var outExtentSymbol = SymbolFactory.Instance.ConstructPointSymbol();
-                var symbol = SymbolFactory.Instance.ConstructMarker(CIMColor.CreateRGBColor(255, 0, 0), 12, SimpleMarkerStyle.X);
+                var symbol = SymbolFactory.Instance.ConstructMarker(CIMColor.CreateRGBColor(0, 0, 255), 12, SimpleMarkerStyle.X);
                 outExtentSymbol.SymbolLayers = new CIMSymbolLayer[1] { symbol };
 
                 var outOfExtent = new CIMUniqueValueClass()
@@ -1103,7 +1103,6 @@ namespace ProAppVisibilityModule.Helpers
                     Symbol = new CIMSymbolReference() { Symbol = outExtentSymbol }
                 };
                 classes.Add(outOfExtent);
-
 
                 CIMUniqueValueGroup groupOne = new CIMUniqueValueGroup();
                 groupOne.Heading = "Out Of Extent";

--- a/source/addins/ProAppVisibilityModule/ViewModels/ProRLOSViewModel.cs
+++ b/source/addins/ProAppVisibilityModule/ViewModels/ProRLOSViewModel.cs
@@ -221,6 +221,8 @@ namespace ProAppVisibilityModule.ViewModels
         }
 
         public bool ShowNonVisibleData { get; set; }
+        public bool ShowClassicViewshed { get; set; }
+
         public int RunCount { get; set; }
 
         private Visibility _displayProgressBar = Visibility.Collapsed;
@@ -500,7 +502,7 @@ namespace ProAppVisibilityModule.ViewModels
                 var outOfExtent = new ObservableCollection<AddInPoint>(RLOS_ObserversOutOfExtent.Select(x => x.AddInPoint).Union(ObserverOutExtentPoints));
                 await FeatureClassHelper.CreatingFeatures(ObserversLayerName, outOfExtent, GetAsMapZUnits(surfaceSR, ObserverOffset.Value), VisibilityLibrary.Properties.Resources.IsOutOfExtentFieldName);
 
-                await FeatureClassHelper.CreateUniqueValueRenderer(GetLayerFromMapByName(RLOSConvertedPolygonsLayerName) as FeatureLayer, ShowNonVisibleData, RLOSConvertedPolygonsLayerName);
+                await FeatureClassHelper.CreateUniqueValueRenderer(GetLayerFromMapByName(RLOSConvertedPolygonsLayerName) as FeatureLayer, ShowNonVisibleData, RLOSConvertedPolygonsLayerName, ShowClassicViewshed);
 
                 var observersLayer = GetLayerFromMapByName(ObserversLayerName) as FeatureLayer;
 

--- a/source/addins/VisibilityLibrary/MAResourceDictionary.xaml
+++ b/source/addins/VisibilityLibrary/MAResourceDictionary.xaml
@@ -60,7 +60,51 @@
         </Style.Triggers>
 
     </Style>
-    <Style x:Key="buttonProperties" TargetType="Button">
+    <Style x:Key="BorderedButtonStyle" TargetType="{x:Type Button}">
+        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="BorderBrush" Value="#9FCDE8"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Foreground" Value="#FFFFFF"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Button}">
+                    <Border Name="Chrome"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                SnapsToDevicePixels="true">
+                        <ContentPresenter Name="Presenter" Margin="{TemplateBinding Padding}"
+                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    RecognizesAccessKey="True"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Foreground" Value="#FFFFFF" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="#E2F1FB" />
+                            <Setter Property="BorderBrush" Value="#9FCDE8" />
+                            <Setter Property="Foreground" Value="#FFFFFF" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter Property="Background" Value="#90CDF2" />
+                            <Setter Property="BorderBrush" Value="#007AC2"/>
+                            <Setter Property="Foreground" Value="#FFFFFF"/>
+                        </Trigger>
+                        <Trigger Property="IsFocused" Value="true">
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="#007AC2" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <Style x:Key="buttonProperties" TargetType="Button" BasedOn="{StaticResource BorderedButtonStyle}">
         <Setter Property="Content">
             <Setter.Value>
                 <Image
@@ -69,10 +113,8 @@
                     Source="/VisibilityLibrary;component/Images/GeoprocessingEnvironmentSettings16.png" />
             </Setter.Value>
         </Setter>
-        <Setter Property="Background" Value="Transparent"/>
         <Setter Property="Command" Value="{Binding EditPropertiesDialogCommand}" />
         <Setter Property="ToolTip" Value="{x:Static prop:Resources.TooltipEditProperties}" />
-        <Setter Property="IsEnabled" Value="True" />
         <Style.Triggers>
             <DataTrigger Binding="{Binding IsRunning}" Value="True">
                 <Setter Property="IsEnabled" Value="False" />
@@ -124,5 +166,54 @@
                 <Setter Property="Background" Value="Transparent"/>
             </Trigger>
         </Style.Triggers>
-    </Style>    
+    </Style>
+    <Style x:Key="BorderedTButtonStyle" TargetType="{x:Type ToggleButton}">
+        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="BorderBrush" Value="#9FCDE8"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Foreground" Value="#FFFFFF"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToggleButton}">
+                    <Border Name="Chrome"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                SnapsToDevicePixels="true">
+                        <ContentPresenter Name="Presenter" Margin="{TemplateBinding Padding}"
+                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    RecognizesAccessKey="True"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Foreground" Value="#FFFFFF" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="#E2F1FB" />
+                            <Setter Property="BorderBrush" Value="#9FCDE8" />
+                            <Setter Property="Foreground" Value="#FFFFFF" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter Property="Background" Value="#90CDF2" />
+                            <Setter Property="BorderBrush" Value="#007AC2"/>
+                            <Setter Property="Foreground" Value="#FFFFFF"/>
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter Property="Background" Value="#90CDF2" />
+                            <Setter Property="BorderBrush" Value="#1ba1e2"/>
+                            <Setter Property="Foreground" Value="#FFFFFF"/>
+                        </Trigger>
+                        <Trigger Property="IsFocused" Value="true">
+                            <Setter TargetName="Chrome" Property="BorderBrush" Value="#007AC2" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 </ResourceDictionary>

--- a/source/addins/VisibilityLibrary/Properties/Resources.Designer.cs
+++ b/source/addins/VisibilityLibrary/Properties/Resources.Designer.cs
@@ -520,6 +520,15 @@ namespace VisibilityLibrary.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show output in Classic Viewshed.
+        /// </summary>
+        public static string LabelShowClassicViewshed {
+            get {
+                return ResourceManager.GetString("LabelShowClassicViewshed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Submit.
         /// </summary>
         public static string LabelSubmit {

--- a/source/addins/VisibilityLibrary/Properties/Resources.resx
+++ b/source/addins/VisibilityLibrary/Properties/Resources.resx
@@ -435,4 +435,7 @@
   <data name="OutOfExtentMsg" xml:space="preserve">
     <value>No data in side the surface extent to process.</value>
   </data>
+  <data name="LabelShowClassicViewshed" xml:space="preserve">
+    <value>Show output in Classic Viewshed</value>
+  </data>
 </root>

--- a/source/addins/VisibilityLibrary/Views/LLOSView.xaml
+++ b/source/addins/VisibilityLibrary/Views/LLOSView.xaml
@@ -57,6 +57,7 @@
                 <TextBlock
                     Grid.ColumnSpan="3"
                     Margin="3,3,0,0"
+                    Grid.Row="0"
                     Text="{x:Static prop:Resources.LabelInputSurface}" />
                 <Grid Grid.Row="1" Grid.ColumnSpan="3">
                     <Grid.ColumnDefinitions>
@@ -118,8 +119,7 @@
                     Grid.Row="4"
                     Grid.Column="2"
                     Margin="3,3,0,0"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Center"
+                    Style="{StaticResource BorderedTButtonStyle}"
                     IsChecked="{Binding ObserverToolActive}"
                     Command="{Binding ActivateToolCommand}"
                     CommandParameter="{x:Static prop:Resources.ToolModeObserver}"
@@ -128,17 +128,6 @@
                         Width="16"
                         Height="16"
                         Source="/VisibilityLibrary;component/Images/Add_Point.png" />
-                    <ToggleButton.Style>
-                        <Style TargetType="ToggleButton">
-                            <Setter Property="Background" Value="Transparent"/>
-                            <Setter Property="IsEnabled" Value="True" />
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding IsRunning}" Value="True">
-                                    <Setter Property="IsEnabled" Value="False" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </ToggleButton.Style>
                 </ToggleButton>
                 <ListBox
                     x:Name="listBoxObservers"
@@ -223,8 +212,8 @@
                     Grid.Row="8"
                     Grid.Column="2"
                     Margin="3,3,0,0"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Center"
+                    
+                    Style="{StaticResource BorderedTButtonStyle}"
                     Command="{Binding ActivateToolCommand}"
                     CommandParameter="{x:Static prop:Resources.ToolModeTarget}"
                     IsChecked="{Binding TargetToolActive}"
@@ -233,17 +222,6 @@
                         Width="16"
                         Height="16"
                         Source="/VisibilityLibrary;component/Images/Add_Point.png" />
-                    <ToggleButton.Style>
-                        <Style TargetType="ToggleButton">
-                            <Setter Property="Background" Value="Transparent"/>
-                            <Setter Property="IsEnabled" Value="True" />
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding IsRunning}" Value="True">
-                                    <Setter Property="IsEnabled" Value="False" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </ToggleButton.Style>
                 </ToggleButton>
                 <ListBox
                     x:Name="listBoxTargets"

--- a/source/addins/VisibilityLibrary/Views/RLOSView.xaml
+++ b/source/addins/VisibilityLibrary/Views/RLOSView.xaml
@@ -38,6 +38,7 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+		    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
                 <ProgressBar
@@ -207,8 +208,29 @@
                         </Style>
                     </CheckBox.Style>
                 </CheckBox>
-                <StackPanel
+                <CheckBox
                     Grid.Row="7"
+                    Grid.ColumnSpan="3"
+                    Margin="3,9,0,0"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Top"
+                    Content="{x:Static prop:Resources.LabelShowClassicViewshed}"
+                    IsChecked="{Binding ShowClassicViewshed}"
+                    ToolTip="{x:Static prop:Resources.LabelShowClassicViewshed}">
+                    <CheckBox.Style>
+                        <Style TargetType="CheckBox" BasedOn="{StaticResource {x:Type CheckBox}}">
+                            <Setter Property="IsEnabled" Value="True" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsRunning}" Value="True">
+                                    <Setter Property="IsEnabled" Value="False" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </CheckBox.Style>
+                </CheckBox>
+
+                <StackPanel
+                    Grid.Row="8"
                     Grid.ColumnSpan="3"
                     HorizontalAlignment="Right"
                     Orientation="Horizontal">
@@ -303,7 +325,7 @@
                 </StackPanel>
                 
                 <Expander
-                    Grid.Row="8"
+                    Grid.Row="9"
                     Grid.ColumnSpan="3"
                     Margin="3,3,0,0"
                     HorizontalAlignment="Stretch"

--- a/source/addins/VisibilityLibrary/Views/RLOSView.xaml
+++ b/source/addins/VisibilityLibrary/Views/RLOSView.xaml
@@ -119,8 +119,7 @@
                     Grid.Row="4"
                     Grid.Column="2"
                     Margin="3,3,0,0"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Center"
+                    Style="{StaticResource BorderedTButtonStyle}"
                     IsChecked="{Binding ObserverToolActive}"
                     Command="{Binding ActivateToolCommand}"
                     CommandParameter="{x:Static prop:Resources.ToolModeObserver}"
@@ -130,17 +129,6 @@
                         Height="16"
                         HorizontalAlignment="Right"
                         Source="/VisibilityLibrary;component/Images/Add_Point.png" />
-                    <ToggleButton.Style>
-                        <Style TargetType="ToggleButton">
-                            <Setter Property="Background" Value="Transparent"/>
-                            <Setter Property="IsEnabled" Value="True" />
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding IsRunning}" Value="True">
-                                    <Setter Property="IsEnabled" Value="False" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </ToggleButton.Style>
                 </ToggleButton>
                 <ListBox
                     x:Name="listBoxObservers"


### PR DESCRIPTION
This build addresses the GitHub tickets mentioned below:

- #162 - LLOS- 3D Target output labels are difficult to read in ArcGIS Pro
- #216 - RLOS - No style applied to output
- #288 - To verify that the visibility add in in dark theme  buttons do not switch to light version while tools are processing
- Updated symbology for out of extent observers and targets